### PR TITLE
방 전체 조회, 생성, 수정 로직 구현

### DIFF
--- a/src/main/java/ei/algobaroapi/domain/room/controller/RoomControllerDocImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/room/controller/RoomControllerDocImpl.java
@@ -1,6 +1,7 @@
 package ei.algobaroapi.domain.room.controller;
 
 import ei.algobaroapi.domain.room.dto.request.RoomCreateRequestDto;
+import ei.algobaroapi.domain.room.dto.request.RoomListRequestDto;
 import ei.algobaroapi.domain.room.dto.request.RoomUpdateRequestDto;
 import ei.algobaroapi.domain.room.dto.response.RoomDetailResponseDto;
 import ei.algobaroapi.domain.room.dto.response.RoomSubmitCodeResponseDto;
@@ -10,6 +11,7 @@ import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -26,8 +28,9 @@ public class RoomControllerDocImpl implements RoomControllerDoc {
 
     @Override
     @GetMapping("/rooms")
-    public List<RoomDetailResponseDto> getAllRooms() {
-        return roomService.getAllRooms();
+    public List<RoomDetailResponseDto> getAllRooms(
+            @ModelAttribute @Valid RoomListRequestDto roomListRequestDto) {
+        return roomService.getAllRooms(roomListRequestDto);
     }
 
     @Override
@@ -52,7 +55,8 @@ public class RoomControllerDocImpl implements RoomControllerDoc {
 
     @Override
     @GetMapping("/rooms/codes/{roomId}")
-    public List<RoomSubmitCodeResponseDto> getSubmitCodesByRoomId(@PathVariable(name = "roomId") Long roomId) {
+    public List<RoomSubmitCodeResponseDto> getSubmitCodesByRoomId(
+            @PathVariable(name = "roomId") Long roomId) {
         return null;
     }
 }

--- a/src/main/java/ei/algobaroapi/domain/room/controller/RoomControllerDocImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/room/controller/RoomControllerDocImpl.java
@@ -27,21 +27,21 @@ public class RoomControllerDocImpl implements RoomControllerDoc {
     @Override
     @GetMapping("/rooms")
     public List<RoomDetailResponseDto> getAllRooms() {
-        return null;
+        return roomService.getAllRooms();
     }
 
     @Override
     @PostMapping("/rooms")
     public RoomDetailResponseDto createRoom(
             @RequestBody @Valid RoomCreateRequestDto roomCreateRequestDto) {
-        return null;
+        return roomService.createRoom(roomCreateRequestDto);
     }
 
     @Override
     @PatchMapping("/rooms/{roomId}")
     public RoomDetailResponseDto updateRoomById(@PathVariable(name = "roomId") Long roomId,
             @RequestBody @Valid RoomUpdateRequestDto roomUpdateRequestDto) {
-        return null;
+        return roomService.updateRoomByRoomId(roomId, roomUpdateRequestDto);
     }
 
     @Override

--- a/src/main/java/ei/algobaroapi/domain/room/domain/Room.java
+++ b/src/main/java/ei/algobaroapi/domain/room/domain/Room.java
@@ -1,7 +1,8 @@
 package ei.algobaroapi.domain.room.domain;
 
-import ei.algobaroapi.global.util.StringListConverter;
+import ei.algobaroapi.domain.room.dto.request.RoomUpdateRequestDto;
 import ei.algobaroapi.global.entity.BaseEntity;
+import ei.algobaroapi.global.util.StringListConverter;
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
@@ -15,6 +16,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -71,4 +73,60 @@ public class Room extends BaseEntity {
 
     @Column(name = "room_uuid", nullable = false)
     private UUID roomUUID;
+
+    @Builder
+    public Room(RoomStatus roomStatus, String title, String introduce, LocalDateTime startAt,
+            RoomAccessType roomAccessType, String problemLink, String problemPlatform,
+            String problemName, String password, int roomLimit, List<String> levelTag,
+            List<String> algorithmTag, UUID roomUUID) {
+        this.roomStatus = roomStatus;
+        this.title = title;
+        this.introduce = introduce;
+        this.startAt = startAt;
+        this.roomAccessType = roomAccessType;
+        this.problemLink = problemLink;
+        this.problemPlatform = problemPlatform;
+        this.problemName = problemName;
+        this.password = password;
+        this.roomLimit = roomLimit;
+        this.levelTag = levelTag;
+        this.algorithmTag = algorithmTag;
+        this.roomUUID = roomUUID;
+    }
+
+    public void update(RoomUpdateRequestDto roomUpdateRequestDto) {
+        if (roomUpdateRequestDto.getTitle() != null) {
+            this.title = roomUpdateRequestDto.getTitle();
+        }
+        if (roomUpdateRequestDto.getIntroduce() != null) {
+            this.introduce = roomUpdateRequestDto.getIntroduce();
+        }
+        if (roomUpdateRequestDto.getStartAt() != null) {
+            this.startAt = roomUpdateRequestDto.getStartAt();
+        }
+        if (roomUpdateRequestDto.getRoomAccessType() != null) {
+            this.roomAccessType = roomUpdateRequestDto.getRoomAccessType();
+        }
+        if (roomUpdateRequestDto.getProblemLink() != null) {
+            this.problemLink = roomUpdateRequestDto.getProblemLink();
+        }
+        if (roomUpdateRequestDto.getProblemPlatform() != null) {
+            this.problemPlatform = roomUpdateRequestDto.getProblemPlatform();
+        }
+        if (roomUpdateRequestDto.getProblemName() != null) {
+            this.problemName = roomUpdateRequestDto.getProblemName();
+        }
+        if (roomUpdateRequestDto.getPassword() != null) {
+            this.password = roomUpdateRequestDto.getPassword();
+        }
+        if (roomUpdateRequestDto.getRoomLimit() > 0) {
+            this.roomLimit = roomUpdateRequestDto.getRoomLimit();
+        }
+        if (roomUpdateRequestDto.getLevelTag() != null) {
+            this.levelTag = roomUpdateRequestDto.getLevelTag();
+        }
+        if (roomUpdateRequestDto.getAlgorithmTag() != null) {
+            this.algorithmTag = roomUpdateRequestDto.getAlgorithmTag();
+        }
+    }
 }

--- a/src/main/java/ei/algobaroapi/domain/room/domain/RoomRepository.java
+++ b/src/main/java/ei/algobaroapi/domain/room/domain/RoomRepository.java
@@ -1,0 +1,9 @@
+package ei.algobaroapi.domain.room.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RoomRepository extends JpaRepository<Room, Long> {
+
+}

--- a/src/main/java/ei/algobaroapi/domain/room/dto/request/RoomCreateRequestDto.java
+++ b/src/main/java/ei/algobaroapi/domain/room/dto/request/RoomCreateRequestDto.java
@@ -4,6 +4,7 @@ import ei.algobaroapi.domain.room.domain.Room;
 import ei.algobaroapi.domain.room.domain.RoomAccessType;
 import ei.algobaroapi.domain.room.domain.RoomStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
@@ -15,33 +16,41 @@ import lombok.Getter;
 @Schema(description = "방 생성 요청 정보")
 public class RoomCreateRequestDto {
 
-    @Schema(description = "방 상태", example = "문제 푸는 중")
+    @NotNull
+    @Schema(description = "방 상태", example = "RECRUITING")
     private RoomStatus roomStatus;
 
+    @NotNull
     @Schema(description = "방 제목", example = "같이 푸실분~")
     private String title;
 
     @Schema(description = "방 소개", example = "저랑 같이 A+B 문제 푸실 분 구해요")
     private String introduce;
 
+    @NotNull
     @Schema(description = "방 시작 시간", example = "2024-2-18T17:30:00")
     private LocalDateTime startAt;
 
-    @Schema(description = "방 접근 정보", example = "공개 방")
+    @NotNull
+    @Schema(description = "방 접근 정보", example = "PUBLIC")
     private RoomAccessType roomAccessType;
 
+    @NotNull
     @Schema(description = "문제 링크", example = "https://www.acmicpc.net/problem/1000")
     private String problemLink;
 
+    @NotNull
     @Schema(description = "문제 플랫폼", example = "백준")
     private String problemPlatform;
 
+    @NotNull
     @Schema(description = "문제 이름", example = "A+B")
     private String problemName;
 
     @Schema(description = "방 비밀번호", example = "password1234")
     private String password;
 
+    @NotNull
     @Schema(description = "방 최대 인원", example = "4")
     private int roomLimit;
 
@@ -51,6 +60,7 @@ public class RoomCreateRequestDto {
     @Schema(description = "문제 알고리즘 종류", example = "BFS")
     private List<String> algorithmTag;
 
+    @NotNull
     @Schema(description = "방 UUID", example = "2ad2e9db-30af-4fa2-895c-b6b1f7e95203")
     private UUID roomUUID;
 

--- a/src/main/java/ei/algobaroapi/domain/room/dto/request/RoomCreateRequestDto.java
+++ b/src/main/java/ei/algobaroapi/domain/room/dto/request/RoomCreateRequestDto.java
@@ -1,5 +1,6 @@
 package ei.algobaroapi.domain.room.dto.request;
 
+import ei.algobaroapi.domain.room.domain.Room;
 import ei.algobaroapi.domain.room.domain.RoomAccessType;
 import ei.algobaroapi.domain.room.domain.RoomStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -52,4 +53,22 @@ public class RoomCreateRequestDto {
 
     @Schema(description = "방 UUID", example = "2ad2e9db-30af-4fa2-895c-b6b1f7e95203")
     private UUID roomUUID;
+
+    public Room toEntity() {
+        return Room.builder()
+                .roomStatus(roomStatus)
+                .title(title)
+                .introduce(introduce)
+                .startAt(startAt)
+                .roomAccessType(roomAccessType)
+                .problemLink(problemLink)
+                .problemPlatform(problemPlatform)
+                .problemName(problemName)
+                .password(password)
+                .roomLimit(roomLimit)
+                .levelTag(levelTag)
+                .algorithmTag(algorithmTag)
+                .roomUUID(roomUUID)
+                .build();
+    }
 }

--- a/src/main/java/ei/algobaroapi/domain/room/dto/request/RoomListRequestDto.java
+++ b/src/main/java/ei/algobaroapi/domain/room/dto/request/RoomListRequestDto.java
@@ -1,0 +1,17 @@
+package ei.algobaroapi.domain.room.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Schema(description = "방 리스트 조회 요청 정보")
+@Getter
+@Builder
+public class RoomListRequestDto {
+
+    @Schema(description = "페이지 번호", example = "0")
+    private Integer page;
+
+    @Schema(description = "페이지 크기", example = "6")
+    private Integer size;
+}

--- a/src/main/java/ei/algobaroapi/domain/room/dto/request/RoomUpdateRequestDto.java
+++ b/src/main/java/ei/algobaroapi/domain/room/dto/request/RoomUpdateRequestDto.java
@@ -2,6 +2,7 @@ package ei.algobaroapi.domain.room.dto.request;
 
 import ei.algobaroapi.domain.room.domain.RoomAccessType;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,8 +18,14 @@ public class RoomUpdateRequestDto {
     @Schema(description = "방 소개", example = "저랑 같이 A+B 문제 푸실 분 구해요")
     private String introduce;
 
+    @Schema(description = "방 시작 시간", example = "2024-2-18T17:30:00")
+    private LocalDateTime startAt;
+
     @Schema(description = "방 접근 정보", example = "공개 방")
     private RoomAccessType roomAccessType;
+
+    @Schema(description = "문제 링크", example = "https://www.acmicpc.net/problem/1000")
+    private String problemLink;
 
     @Schema(description = "문제 플랫폼", example = "백준")
     private String problemPlatform;
@@ -36,5 +43,5 @@ public class RoomUpdateRequestDto {
     private List<String> levelTag;
 
     @Schema(description = "문제 알고리즘 종류", example = "BFS")
-    private List<String> algorithmTage;
+    private List<String> algorithmTag;
 }

--- a/src/main/java/ei/algobaroapi/domain/room/exception/RoomNotFoundException.java
+++ b/src/main/java/ei/algobaroapi/domain/room/exception/RoomNotFoundException.java
@@ -1,0 +1,20 @@
+package ei.algobaroapi.domain.room.exception;
+
+import ei.algobaroapi.domain.room.exception.common.RoomErrorCode;
+import lombok.Getter;
+
+@Getter
+public class RoomNotFoundException extends RuntimeException {
+
+    private final String errorCode;
+    private final String errorMessage;
+
+    private RoomNotFoundException(RoomErrorCode errorCode) {
+        this.errorCode = errorCode.getErrorCode();
+        this.errorMessage = errorCode.getErrorMessage();
+    }
+
+    public static RoomNotFoundException of(RoomErrorCode errorCode) {
+        return new RoomNotFoundException(errorCode);
+    }
+}

--- a/src/main/java/ei/algobaroapi/domain/room/exception/common/RoomErrorCode.java
+++ b/src/main/java/ei/algobaroapi/domain/room/exception/common/RoomErrorCode.java
@@ -1,0 +1,14 @@
+package ei.algobaroapi.domain.room.exception.common;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum RoomErrorCode {
+
+    ROOM_NOT_FOUND("E03301", "방을 찾지 못했습니다.");
+
+    private final String errorCode;
+    private final String errorMessage;
+}

--- a/src/main/java/ei/algobaroapi/domain/room/exception/common/RoomExceptionHandler.java
+++ b/src/main/java/ei/algobaroapi/domain/room/exception/common/RoomExceptionHandler.java
@@ -1,0 +1,22 @@
+package ei.algobaroapi.domain.room.exception.common;
+
+import ei.algobaroapi.domain.auth.exception.AuthPasswordException;
+import ei.algobaroapi.domain.room.exception.RoomNotFoundException;
+import ei.algobaroapi.global.response.message.ErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class RoomExceptionHandler {
+
+    @ExceptionHandler(RoomNotFoundException.class)
+    public ResponseEntity<ErrorResponse> catchRoomNotFountException(RoomNotFoundException e) {
+        log.warn(e.getErrorMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ErrorResponse.of(e.getErrorCode(), e.getErrorMessage()));
+    }
+}

--- a/src/main/java/ei/algobaroapi/domain/room/service/RoomService.java
+++ b/src/main/java/ei/algobaroapi/domain/room/service/RoomService.java
@@ -1,6 +1,7 @@
 package ei.algobaroapi.domain.room.service;
 
 import ei.algobaroapi.domain.room.dto.request.RoomCreateRequestDto;
+import ei.algobaroapi.domain.room.dto.request.RoomListRequestDto;
 import ei.algobaroapi.domain.room.dto.request.RoomUpdateRequestDto;
 import ei.algobaroapi.domain.room.dto.response.RoomDetailResponseDto;
 import ei.algobaroapi.domain.room.dto.response.RoomSubmitCodeResponseDto;
@@ -8,7 +9,7 @@ import java.util.List;
 
 public interface RoomService {
 
-    List<RoomDetailResponseDto> getAllRooms();
+    List<RoomDetailResponseDto> getAllRooms(RoomListRequestDto roomListRequestDto);
 
     RoomDetailResponseDto createRoom(RoomCreateRequestDto roomCreateRequestDto);
 

--- a/src/main/java/ei/algobaroapi/domain/room/service/RoomServiceImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/room/service/RoomServiceImpl.java
@@ -6,6 +6,8 @@ import ei.algobaroapi.domain.room.dto.request.RoomCreateRequestDto;
 import ei.algobaroapi.domain.room.dto.request.RoomUpdateRequestDto;
 import ei.algobaroapi.domain.room.dto.response.RoomDetailResponseDto;
 import ei.algobaroapi.domain.room.dto.response.RoomSubmitCodeResponseDto;
+import ei.algobaroapi.domain.room.exception.RoomNotFoundException;
+import ei.algobaroapi.domain.room.exception.common.RoomErrorCode;
 import jakarta.persistence.EntityNotFoundException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -37,7 +39,7 @@ public class RoomServiceImpl implements RoomService {
     public RoomDetailResponseDto updateRoomByRoomId(Long roomId,
             RoomUpdateRequestDto roomUpdateRequestDto) {
         Room room = roomRepository.findById(roomId)
-                .orElseThrow(() -> new EntityNotFoundException("방을 찾지 못했습니다."));
+                .orElseThrow(() -> RoomNotFoundException.of(RoomErrorCode.ROOM_NOT_FOUND));
 
         room.update(roomUpdateRequestDto);
 

--- a/src/main/java/ei/algobaroapi/domain/room/service/RoomServiceImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/room/service/RoomServiceImpl.java
@@ -3,14 +3,16 @@ package ei.algobaroapi.domain.room.service;
 import ei.algobaroapi.domain.room.domain.Room;
 import ei.algobaroapi.domain.room.domain.RoomRepository;
 import ei.algobaroapi.domain.room.dto.request.RoomCreateRequestDto;
+import ei.algobaroapi.domain.room.dto.request.RoomListRequestDto;
 import ei.algobaroapi.domain.room.dto.request.RoomUpdateRequestDto;
 import ei.algobaroapi.domain.room.dto.response.RoomDetailResponseDto;
 import ei.algobaroapi.domain.room.dto.response.RoomSubmitCodeResponseDto;
 import ei.algobaroapi.domain.room.exception.RoomNotFoundException;
 import ei.algobaroapi.domain.room.exception.common.RoomErrorCode;
-import jakarta.persistence.EntityNotFoundException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,8 +24,11 @@ public class RoomServiceImpl implements RoomService {
     private final RoomRepository roomRepository;
 
     @Override
-    public List<RoomDetailResponseDto> getAllRooms() {
-        return roomRepository.findAll().stream()
+    public List<RoomDetailResponseDto> getAllRooms(RoomListRequestDto roomListRequestDto) {
+        Pageable pageable = PageRequest.of(roomListRequestDto.getPage(),
+                roomListRequestDto.getSize());
+
+        return roomRepository.findAll(pageable).getContent().stream()
                 .map(RoomDetailResponseDto::of)
                 .toList();
     }

--- a/src/main/java/ei/algobaroapi/domain/room/service/RoomServiceImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/room/service/RoomServiceImpl.java
@@ -1,30 +1,47 @@
 package ei.algobaroapi.domain.room.service;
 
+import ei.algobaroapi.domain.room.domain.Room;
+import ei.algobaroapi.domain.room.domain.RoomRepository;
 import ei.algobaroapi.domain.room.dto.request.RoomCreateRequestDto;
 import ei.algobaroapi.domain.room.dto.request.RoomUpdateRequestDto;
 import ei.algobaroapi.domain.room.dto.response.RoomDetailResponseDto;
 import ei.algobaroapi.domain.room.dto.response.RoomSubmitCodeResponseDto;
+import jakarta.persistence.EntityNotFoundException;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Transactional(readOnly = true)
+@RequiredArgsConstructor
 public class RoomServiceImpl implements RoomService {
+
+    private final RoomRepository roomRepository;
 
     @Override
     public List<RoomDetailResponseDto> getAllRooms() {
-        return null;
+        return roomRepository.findAll().stream()
+                .map(RoomDetailResponseDto::of)
+                .toList();
     }
 
     @Override
+    @Transactional
     public RoomDetailResponseDto createRoom(RoomCreateRequestDto roomCreateRequestDto) {
-        return null;
+        return RoomDetailResponseDto.of(roomRepository.save(roomCreateRequestDto.toEntity()));
     }
 
     @Override
-    public RoomDetailResponseDto updateRoomByRoomId(Long roomId, RoomUpdateRequestDto roomUpdateRequestDto) {
-        return null;
+    @Transactional
+    public RoomDetailResponseDto updateRoomByRoomId(Long roomId,
+            RoomUpdateRequestDto roomUpdateRequestDto) {
+        Room room = roomRepository.findById(roomId)
+                .orElseThrow(() -> new EntityNotFoundException("방을 찾지 못했습니다."));
+
+        room.update(roomUpdateRequestDto);
+
+        return RoomDetailResponseDto.of(room);
     }
 
     @Override

--- a/src/main/java/ei/algobaroapi/global/config/swaggerdoc/RoomControllerDoc.java
+++ b/src/main/java/ei/algobaroapi/global/config/swaggerdoc/RoomControllerDoc.java
@@ -1,6 +1,7 @@
 package ei.algobaroapi.global.config.swaggerdoc;
 
 import ei.algobaroapi.domain.room.dto.request.RoomCreateRequestDto;
+import ei.algobaroapi.domain.room.dto.request.RoomListRequestDto;
 import ei.algobaroapi.domain.room.dto.request.RoomUpdateRequestDto;
 import ei.algobaroapi.domain.room.dto.response.RoomDetailResponseDto;
 import ei.algobaroapi.domain.room.dto.response.RoomSubmitCodeResponseDto;
@@ -13,16 +14,17 @@ import java.util.List;
 @SuppressWarnings("unused")
 public interface RoomControllerDoc {
 
-    @Operation(summary = "모든 방 정보 조회 - 작업 중", description = "현재 존재하는 모든 방 정보를 조회합니다.")
+    @Operation(summary = "모든 방 정보 조회", description = "현재 존재하는 모든 방 정보를 조회합니다.")
     @ApiResponse(responseCode = "200", description = "방 정보 조회 성공")
-    List<RoomDetailResponseDto> getAllRooms();
+    List<RoomDetailResponseDto> getAllRooms(RoomListRequestDto roomListRequestDto);
 
-    @Operation(summary = "방 생성 - 작업 중", description = "새로운 방을 생성합니다.")
+    @Operation(summary = "방 생성", description = "새로운 방을 생성합니다.")
     @ApiResponse(responseCode = "200", description = "방 생성 성공")
     RoomDetailResponseDto createRoom(RoomCreateRequestDto roomCreateRequestDto);
 
-    @Operation(summary = "방 수정 - 작업 중", description = "방 정보를 수정합니다.")
+    @Operation(summary = "방 수정", description = "방 정보를 수정합니다.")
     @ApiResponse(responseCode = "200", description = "방 수정 성공")
+    @ApiResponse(responseCode = "E03301", description = "수정하려는 방 정보를 찾지 못했습니다.")
     RoomDetailResponseDto updateRoomById(Long roomId, RoomUpdateRequestDto roomUpdateRequestDto);
 
     @Operation(summary = "문제 풀이 시작 - 작업 중", description = "코딩테스트를 시작합니다.")


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

방에 대한 기본적인 기능을 구현하였습니다.
- getAllViews
- createRoom
- updateRoomByRoomId

---

프론트 요구사항
방 조회 - 방 고유번호, 사용자 정의태그, 제한시간, 참가자 정보
방 수정 - 문제 링크, 제한 시간

## 💬리뷰 시 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

게더에 올렸던 질문이지만 한 번 더 올려봅니다.
현재 updateRequestDto에는 여러 필드가 존재하는데 Bean Validation을 사용하지 못합니다.(@PatchMapping을 사용)
update를 위해 엔티티에서 검증을 진행해야 하는데, 필드가 많다보니 여러 분기문이 생기면서 이렇게 해야 하는 것 같다고 생각은 하지만 이상하다고 느껴 질문드립니다.
검증 관련해서는 필요 로직 구현 이후 추가하려고 합니다.(Enum 값에 있는 것인지 등등..)

