### PR TITLE
Short UUID를 통해 방 조회할 수 있도록 로직 변경

### DIFF
--- a/src/main/java/ei/algobaroapi/domain/room/controller/RoomControllerDocImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/room/controller/RoomControllerDocImpl.java
@@ -48,9 +48,9 @@ public class RoomControllerDocImpl implements RoomControllerDoc {
     }
 
     @Override
-    @GetMapping("/rooms/{roomUuid}")
-    public RoomDetailResponseDto getRoomByUuid(@PathVariable(name = "roomUuid") String roomUuid) {
-        return roomService.getRoomByRoomUuid(roomUuid);
+    @GetMapping("/rooms/{roomShortUuid}")
+    public RoomDetailResponseDto getRoomByShortUuid(@PathVariable(name = "roomShortUuid") String roomShortUuid) {
+        return roomService.getRoomByRoomUuid(roomShortUuid);
     }
 
     @Override

--- a/src/main/java/ei/algobaroapi/domain/room/controller/RoomControllerDocImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/room/controller/RoomControllerDocImpl.java
@@ -49,7 +49,7 @@ public class RoomControllerDocImpl implements RoomControllerDoc {
 
     @Override
     @GetMapping("/rooms/{roomUuid}")
-    public RoomDetailResponseDto getRoomByUUID(@PathVariable(name = "roomUuid") String roomUuid) {
+    public RoomDetailResponseDto getRoomByUuid(@PathVariable(name = "roomUuid") String roomUuid) {
         return roomService.getRoomByRoomUuid(roomUuid);
     }
 

--- a/src/main/java/ei/algobaroapi/domain/room/domain/Room.java
+++ b/src/main/java/ei/algobaroapi/domain/room/domain/Room.java
@@ -77,7 +77,7 @@ public class Room extends BaseEntity {
     public Room(RoomStatus roomStatus, String title, String introduce, LocalDateTime startAt,
             RoomAccessType roomAccessType, String problemLink, String problemPlatform,
             String problemName, String password, Integer roomLimit, List<String> tags,
-            Integer timeLimit, UUID roomUUID) {
+            Integer timeLimit) {
         this.roomStatus = roomStatus;
         this.title = title;
         this.introduce = introduce;
@@ -90,7 +90,7 @@ public class Room extends BaseEntity {
         this.roomLimit = roomLimit;
         this.tags = tags;
         this.timeLimit = timeLimit;
-        this.roomUUID = roomUUID;
+        this.roomUUID = UUID.randomUUID();
     }
 
     public void update(RoomUpdateRequestDto roomUpdateRequestDto) {

--- a/src/main/java/ei/algobaroapi/domain/room/domain/Room.java
+++ b/src/main/java/ei/algobaroapi/domain/room/domain/Room.java
@@ -71,7 +71,7 @@ public class Room extends BaseEntity {
     private List<String> tags;
 
     @Column(name = "room_uuid", nullable = false)
-    private UUID roomUUID;
+    private UUID roomUuid;
 
     @Builder
     public Room(RoomStatus roomStatus, String title, String introduce, LocalDateTime startAt,
@@ -90,7 +90,7 @@ public class Room extends BaseEntity {
         this.roomLimit = roomLimit;
         this.tags = tags;
         this.timeLimit = timeLimit;
-        this.roomUUID = UUID.randomUUID();
+        this.roomUuid = UUID.randomUUID();
     }
 
     public void update(RoomUpdateRequestDto roomUpdateRequestDto) {

--- a/src/main/java/ei/algobaroapi/domain/room/domain/Room.java
+++ b/src/main/java/ei/algobaroapi/domain/room/domain/Room.java
@@ -71,7 +71,7 @@ public class Room extends BaseEntity {
     private List<String> tags;
 
     @Column(name = "room_uuid", nullable = false)
-    private UUID roomUuid;
+    private String roomUuid;
 
     @Builder
     public Room(RoomStatus roomStatus, String title, String introduce, LocalDateTime startAt,
@@ -90,7 +90,7 @@ public class Room extends BaseEntity {
         this.roomLimit = roomLimit;
         this.tags = tags;
         this.timeLimit = timeLimit;
-        this.roomUuid = UUID.randomUUID();
+        this.roomUuid = UUID.randomUUID().toString();
     }
 
     public void update(RoomUpdateRequestDto roomUpdateRequestDto) {

--- a/src/main/java/ei/algobaroapi/domain/room/domain/RoomRepository.java
+++ b/src/main/java/ei/algobaroapi/domain/room/domain/RoomRepository.java
@@ -1,7 +1,6 @@
 package ei.algobaroapi.domain.room.domain;
 
 import java.util.Optional;
-import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -9,6 +8,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface RoomRepository extends JpaRepository<Room, Long> {
 
-    @Query("SELECT r from Room r where r.roomUuid = :roomUuid")
-    Optional<Room> findByRoomUuidWithRoomMember(UUID roomUuid); // TODO: 방 참여 기능 구현 후 쿼리 수정
+    @Query("SELECT r FROM Room r WHERE r.roomUuid LIKE CONCAT(:roomShortUuid, '%')")
+    Optional<Room> findByRoomUuidStartingWith(String roomShortUuid); // TODO: 방 참여 기능 구현 후 쿼리 수정
 }

--- a/src/main/java/ei/algobaroapi/domain/room/domain/RoomRepository.java
+++ b/src/main/java/ei/algobaroapi/domain/room/domain/RoomRepository.java
@@ -9,6 +9,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface RoomRepository extends JpaRepository<Room, Long> {
 
-    @Query("SELECT r from Room r where r.roomUUID = :roomUuid")
+    @Query("SELECT r from Room r where r.roomUuid = :roomUuid")
     Optional<Room> findByRoomUuidWithRoomMember(UUID roomUuid); // TODO: 방 참여 기능 구현 후 쿼리 수정
 }

--- a/src/main/java/ei/algobaroapi/domain/room/dto/request/RoomCreateRequestDto.java
+++ b/src/main/java/ei/algobaroapi/domain/room/dto/request/RoomCreateRequestDto.java
@@ -7,7 +7,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.UUID;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -60,10 +59,6 @@ public class RoomCreateRequestDto {
     @Schema(description = "타이머(Minute)", example = "20")
     private Integer timeLimit;
 
-    @NotNull
-    @Schema(description = "방 UUID", example = "2ad2e9db-30af-4fa2-895c-b6b1f7e95203")
-    private UUID roomUUID;
-
     public Room toEntity() {
         return Room.builder()
                 .roomStatus(roomStatus)
@@ -78,7 +73,6 @@ public class RoomCreateRequestDto {
                 .roomLimit(roomLimit)
                 .tags(tags)
                 .timeLimit(timeLimit)
-                .roomUUID(roomUUID)
                 .build();
     }
 }

--- a/src/main/java/ei/algobaroapi/domain/room/dto/response/RoomDetailResponseDto.java
+++ b/src/main/java/ei/algobaroapi/domain/room/dto/response/RoomDetailResponseDto.java
@@ -47,8 +47,8 @@ public class RoomDetailResponseDto {
     @Schema(description = "타이머(Minute)", example = "20")
     private Integer timeLimit;
 
-    @Schema(description = "방 UUID", example = "2ad2e9db-30af-4fa2-895c-b6b1f7e95203")
-    private UUID roomUUID;
+    @Schema(description = "방 UUID", example = "2ad2e9db")
+    private UUID roomUuid;
 
     public static RoomDetailResponseDto of(Room room) {
         return new RoomDetailResponseDto(
@@ -63,7 +63,7 @@ public class RoomDetailResponseDto {
                 room.getRoomLimit(),
                 room.getTags(),
                 room.getTimeLimit(),
-                room.getRoomUUID()
+                room.getRoomUuid()
         );
     }
 }

--- a/src/main/java/ei/algobaroapi/domain/room/dto/response/RoomDetailResponseDto.java
+++ b/src/main/java/ei/algobaroapi/domain/room/dto/response/RoomDetailResponseDto.java
@@ -47,8 +47,8 @@ public class RoomDetailResponseDto {
     @Schema(description = "타이머(Minute)", example = "20")
     private Integer timeLimit;
 
-    @Schema(description = "방 UUID", example = "2ad2e9db")
-    private UUID roomUuid;
+    @Schema(description = "방 short UUID", example = "2ad2e9db")
+    private String roomShortUuid;
 
     public static RoomDetailResponseDto of(Room room) {
         return new RoomDetailResponseDto(
@@ -63,7 +63,7 @@ public class RoomDetailResponseDto {
                 room.getRoomLimit(),
                 room.getTags(),
                 room.getTimeLimit(),
-                room.getRoomUuid()
+                room.getRoomUuid().split("-")[0]
         );
     }
 }

--- a/src/main/java/ei/algobaroapi/domain/room/service/RoomServiceImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/room/service/RoomServiceImpl.java
@@ -10,7 +10,6 @@ import ei.algobaroapi.domain.room.dto.response.RoomSubmitCodeResponseDto;
 import ei.algobaroapi.domain.room.exception.RoomNotFoundException;
 import ei.algobaroapi.domain.room.exception.common.RoomErrorCode;
 import java.util.List;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -53,9 +52,8 @@ public class RoomServiceImpl implements RoomService {
     }
 
     @Override
-    public RoomDetailResponseDto getRoomByRoomUuid(String roomUuid) {
-        return RoomDetailResponseDto.of(roomRepository.findByRoomUuidWithRoomMember(
-                        UUID.fromString(roomUuid))
+    public RoomDetailResponseDto getRoomByRoomUuid(String roomShortUuid) {
+        return RoomDetailResponseDto.of(roomRepository.findByRoomUuidStartingWith(roomShortUuid)
                 .orElseThrow(() -> RoomNotFoundException.of(RoomErrorCode.ROOM_NOT_FOUND)));
     }
 

--- a/src/main/java/ei/algobaroapi/global/config/swaggerdoc/RoomControllerDoc.java
+++ b/src/main/java/ei/algobaroapi/global/config/swaggerdoc/RoomControllerDoc.java
@@ -27,9 +27,9 @@ public interface RoomControllerDoc {
     @ApiResponse(responseCode = "E03301", description = "수정하려는 방 정보를 찾지 못했습니다.")
     RoomDetailResponseDto updateRoomById(Long roomId, RoomUpdateRequestDto roomUpdateRequestDto);
 
-    @Operation(summary = "개별 방 정보 조회", description = "UUID를 통해 방을 조회합니다.")
+    @Operation(summary = "개별 방 정보 조회", description = "short UUID를 통해 방을 조회합니다.")
     @ApiResponse(responseCode = "200", description = "방 정보 조회 성공")
-    RoomDetailResponseDto getRoomByUuid(String roomUuid);
+    RoomDetailResponseDto getRoomByShortUuid(String roomShortUuid);
 
     @Operation(summary = "문제 풀이 시작 - 작업 중", description = "코딩테스트를 시작합니다.")
     @ApiResponse(responseCode = "200", description = "풀이 시작 성공")

--- a/src/main/java/ei/algobaroapi/global/config/swaggerdoc/RoomControllerDoc.java
+++ b/src/main/java/ei/algobaroapi/global/config/swaggerdoc/RoomControllerDoc.java
@@ -29,7 +29,7 @@ public interface RoomControllerDoc {
 
     @Operation(summary = "개별 방 정보 조회", description = "UUID를 통해 방을 조회합니다.")
     @ApiResponse(responseCode = "200", description = "방 정보 조회 성공")
-    RoomDetailResponseDto getRoomByUUID(String roomUuid);
+    RoomDetailResponseDto getRoomByUuid(String roomUuid);
 
     @Operation(summary = "문제 풀이 시작 - 작업 중", description = "코딩테스트를 시작합니다.")
     @ApiResponse(responseCode = "200", description = "풀이 시작 성공")


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

엔티티의 UUID 타입 변경 (UUID -> String)

데이터베이스에는 UUID 전체가 String 형태로 저장됩니다.
RoomDetailResponseDto 에서는 해당 방의 UUID를 첫 "-" 기준으로 앞 문자만 반환합니다.
a33c4e99-a33c4e99-a33c4e99 -> a33c4e99 만 반환

## 💬리뷰 시 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


