### PR TITLE
방 참여 기능 구현 및 일부 로직 수정

### DIFF
--- a/src/main/java/ei/algobaroapi/domain/room/controller/RoomControllerDocImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/room/controller/RoomControllerDocImpl.java
@@ -4,7 +4,7 @@ import ei.algobaroapi.domain.member.domain.Member;
 import ei.algobaroapi.domain.room.dto.request.RoomCreateRequestDto;
 import ei.algobaroapi.domain.room.dto.request.RoomListRequestDto;
 import ei.algobaroapi.domain.room.dto.request.RoomUpdateRequestDto;
-import ei.algobaroapi.domain.room.dto.response.RoomDetailResponseDto;
+import ei.algobaroapi.domain.room.dto.response.RoomResponseDto;
 import ei.algobaroapi.domain.room.dto.response.RoomSubmitCodeResponseDto;
 import ei.algobaroapi.domain.room.service.RoomService;
 import ei.algobaroapi.global.config.swaggerdoc.RoomControllerDoc;
@@ -31,7 +31,7 @@ public class RoomControllerDocImpl implements RoomControllerDoc {
 
     @Override
     @GetMapping("/rooms")
-    public List<RoomDetailResponseDto> getAllRooms(
+    public List<RoomResponseDto> getAllRooms(
             @ModelAttribute @Valid RoomListRequestDto roomListRequestDto) {
         return roomService.getAllRooms(roomListRequestDto);
     }
@@ -39,7 +39,7 @@ public class RoomControllerDocImpl implements RoomControllerDoc {
     @Override
     @PostMapping("/rooms")
     @PreAuthorize("hasRole('USER')")
-    public RoomDetailResponseDto createRoom(
+    public RoomResponseDto createRoom(
             @RequestBody @Valid RoomCreateRequestDto roomCreateRequestDto,
             @AuthenticationPrincipal Member member) {
         return roomService.createRoom(roomCreateRequestDto, member);
@@ -47,14 +47,14 @@ public class RoomControllerDocImpl implements RoomControllerDoc {
 
     @Override
     @PatchMapping("/rooms/{roomId}")
-    public RoomDetailResponseDto updateRoomById(@PathVariable(name = "roomId") Long roomId,
+    public RoomResponseDto updateRoomById(@PathVariable(name = "roomId") Long roomId,
             @RequestBody @Valid RoomUpdateRequestDto roomUpdateRequestDto) {
         return roomService.updateRoomByRoomId(roomId, roomUpdateRequestDto);
     }
 
     @Override
     @GetMapping("/rooms/{roomShortUuid}")
-    public RoomDetailResponseDto getRoomByShortUuid(
+    public RoomResponseDto getRoomByShortUuid(
             @PathVariable(name = "roomShortUuid") String roomShortUuid) {
         return roomService.getRoomByRoomUuid(roomShortUuid);
     }

--- a/src/main/java/ei/algobaroapi/domain/room/controller/RoomControllerDocImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/room/controller/RoomControllerDocImpl.java
@@ -4,6 +4,7 @@ import ei.algobaroapi.domain.member.domain.Member;
 import ei.algobaroapi.domain.room.dto.request.RoomCreateRequestDto;
 import ei.algobaroapi.domain.room.dto.request.RoomListRequestDto;
 import ei.algobaroapi.domain.room.dto.request.RoomUpdateRequestDto;
+import ei.algobaroapi.domain.room.dto.response.RoomDetailResponseDto;
 import ei.algobaroapi.domain.room.dto.response.RoomResponseDto;
 import ei.algobaroapi.domain.room.dto.response.RoomSubmitCodeResponseDto;
 import ei.algobaroapi.domain.room.service.RoomService;
@@ -39,7 +40,7 @@ public class RoomControllerDocImpl implements RoomControllerDoc {
     @Override
     @PostMapping("/rooms")
     @PreAuthorize("hasRole('USER')")
-    public RoomResponseDto createRoom(
+    public RoomDetailResponseDto createRoom(
             @RequestBody @Valid RoomCreateRequestDto roomCreateRequestDto,
             @AuthenticationPrincipal Member member) {
         return roomService.createRoom(roomCreateRequestDto, member);
@@ -54,7 +55,7 @@ public class RoomControllerDocImpl implements RoomControllerDoc {
 
     @Override
     @GetMapping("/rooms/{roomShortUuid}")
-    public RoomResponseDto getRoomByShortUuid(
+    public RoomDetailResponseDto getRoomByShortUuid(
             @PathVariable(name = "roomShortUuid") String roomShortUuid) {
         return roomService.getRoomByRoomUuid(roomShortUuid);
     }

--- a/src/main/java/ei/algobaroapi/domain/room/controller/RoomControllerDocImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/room/controller/RoomControllerDocImpl.java
@@ -1,5 +1,6 @@
 package ei.algobaroapi.domain.room.controller;
 
+import ei.algobaroapi.domain.member.domain.Member;
 import ei.algobaroapi.domain.room.dto.request.RoomCreateRequestDto;
 import ei.algobaroapi.domain.room.dto.request.RoomListRequestDto;
 import ei.algobaroapi.domain.room.dto.request.RoomUpdateRequestDto;
@@ -10,6 +11,8 @@ import ei.algobaroapi.global.config.swaggerdoc.RoomControllerDoc;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -35,9 +38,11 @@ public class RoomControllerDocImpl implements RoomControllerDoc {
 
     @Override
     @PostMapping("/rooms")
+    @PreAuthorize("hasRole('USER')")
     public RoomDetailResponseDto createRoom(
-            @RequestBody @Valid RoomCreateRequestDto roomCreateRequestDto) {
-        return roomService.createRoom(roomCreateRequestDto);
+            @RequestBody @Valid RoomCreateRequestDto roomCreateRequestDto,
+            @AuthenticationPrincipal Member member) {
+        return roomService.createRoom(roomCreateRequestDto, member);
     }
 
     @Override
@@ -49,7 +54,8 @@ public class RoomControllerDocImpl implements RoomControllerDoc {
 
     @Override
     @GetMapping("/rooms/{roomShortUuid}")
-    public RoomDetailResponseDto getRoomByShortUuid(@PathVariable(name = "roomShortUuid") String roomShortUuid) {
+    public RoomDetailResponseDto getRoomByShortUuid(
+            @PathVariable(name = "roomShortUuid") String roomShortUuid) {
         return roomService.getRoomByRoomUuid(roomShortUuid);
     }
 

--- a/src/main/java/ei/algobaroapi/domain/room/dto/response/RoomDetailResponseDto.java
+++ b/src/main/java/ei/algobaroapi/domain/room/dto/response/RoomDetailResponseDto.java
@@ -1,0 +1,94 @@
+package ei.algobaroapi.domain.room.dto.response;
+
+import ei.algobaroapi.domain.room.domain.Room;
+import ei.algobaroapi.domain.room.domain.RoomAccessType;
+import ei.algobaroapi.domain.room.domain.RoomStatus;
+import ei.algobaroapi.domain.room_member.dto.response.RoomMemberResponseDto;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "방 참여자가 포함된 개별 상세 정보")
+public class RoomDetailResponseDto {
+
+    @Schema(description = "방 번호", example = "1")
+    private Long roomId;
+
+    @Schema(description = "방 상태", example = "문제 푸는 중")
+    private RoomStatus roomStatus;
+
+    @Schema(description = "방 제목", example = "같이 푸실분~")
+    private String title;
+
+    @Schema(description = "방 소개", example = "저랑 같이 A+B 문제 푸실 분 구해요")
+    private String introduce;
+
+    @Schema(description = "방 접근 정보", example = "공개 방")
+    private RoomAccessType roomAccessType;
+
+    @Schema(description = "문제 플랫폼", example = "백준")
+    private String problemPlatform;
+
+    @Schema(description = "문제 이름", example = "A+B")
+    private String problemName;
+
+    @Schema(description = "방 비밀번호", example = "password1234")
+    private String password;
+
+    @Schema(description = "방 최대 인원", example = "4")
+    private Integer roomLimit;
+
+    @Schema(description = "태그", example = "[\"BFS\", \"Level 1\"]")
+    private List<String> tags;
+
+    @Schema(description = "타이머(Minute)", example = "20")
+    private Integer timeLimit;
+
+    @Schema(description = "방 short UUID", example = "2ad2e9db")
+    private String roomShortUuid;
+
+    @Schema(description = "방 참여자 정보", example =
+            """
+                    [
+                        {
+                            "id": "test1@test.com",
+                            "nickname": "test1",
+                            "profileImage": null,
+                            "role": "HOST",
+                            "joinTime": "2024-03-04T00:45:18",
+                            "ready": true
+                        },
+                        {
+                            "id": "test2@test.com",
+                            "nickname": "test2",
+                            "profileImage": null,
+                            "role": "PARTICIPANT",
+                            "joinTime": "2024-03-04T00:45:36",
+                            "ready": false
+                        }
+                    ]""")
+    private List<RoomMemberResponseDto> roomMembers;
+
+    public static RoomDetailResponseDto of(Room room, List<RoomMemberResponseDto> roomMembers) {
+        return new RoomDetailResponseDto(
+                room.getId(),
+                room.getRoomStatus(),
+                room.getTitle(),
+                room.getIntroduce(),
+                room.getRoomAccessType(),
+                room.getProblemPlatform(),
+                room.getProblemName(),
+                room.getPassword(),
+                room.getRoomLimit(),
+                room.getTags(),
+                room.getTimeLimit(),
+                room.getRoomUuid().split("-")[0],
+                roomMembers
+        );
+    }
+}
+
+

--- a/src/main/java/ei/algobaroapi/domain/room/dto/response/RoomDetailResponseDto.java
+++ b/src/main/java/ei/algobaroapi/domain/room/dto/response/RoomDetailResponseDto.java
@@ -3,9 +3,10 @@ package ei.algobaroapi.domain.room.dto.response;
 import ei.algobaroapi.domain.room.domain.Room;
 import ei.algobaroapi.domain.room.domain.RoomAccessType;
 import ei.algobaroapi.domain.room.domain.RoomStatus;
+import ei.algobaroapi.domain.room_member.dto.response.RoomMemberResponseDto;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -50,6 +51,29 @@ public class RoomDetailResponseDto {
     @Schema(description = "방 short UUID", example = "2ad2e9db")
     private String roomShortUuid;
 
+    @Schema(description = "방 참여자 정보", example =
+            """
+                    [
+                        {
+                            "id": "test1@test.com",
+                            "nickname": "test1",
+                            "profileImage": null,
+                            "role": "HOST",
+                            "joinTime": "2024-03-04T00:45:18",
+                            "ready": true
+                        },
+                        {
+                            "id": "test2@test.com",
+                            "nickname": "test2",
+                            "profileImage": null,
+                            "role": "PARTICIPANT",
+                            "joinTime": "2024-03-04T00:45:36",
+                            "ready": false
+                        }
+                    ]""")
+    private List<RoomMemberResponseDto> roomMembers;
+
+
     public static RoomDetailResponseDto of(Room room) {
         return new RoomDetailResponseDto(
                 room.getId(),
@@ -63,7 +87,26 @@ public class RoomDetailResponseDto {
                 room.getRoomLimit(),
                 room.getTags(),
                 room.getTimeLimit(),
-                room.getRoomUuid().split("-")[0]
+                room.getRoomUuid().split("-")[0],
+                new ArrayList<>()
+        );
+    }
+
+    public static RoomDetailResponseDto of(Room room, List<RoomMemberResponseDto> roomMembers) {
+        return new RoomDetailResponseDto(
+                room.getId(),
+                room.getRoomStatus(),
+                room.getTitle(),
+                room.getIntroduce(),
+                room.getRoomAccessType(),
+                room.getProblemPlatform(),
+                room.getProblemName(),
+                room.getPassword(),
+                room.getRoomLimit(),
+                room.getTags(),
+                room.getTimeLimit(),
+                room.getRoomUuid().split("-")[0],
+                roomMembers
         );
     }
 }

--- a/src/main/java/ei/algobaroapi/domain/room/dto/response/RoomResponseDto.java
+++ b/src/main/java/ei/algobaroapi/domain/room/dto/response/RoomResponseDto.java
@@ -3,9 +3,7 @@ package ei.algobaroapi.domain.room.dto.response;
 import ei.algobaroapi.domain.room.domain.Room;
 import ei.algobaroapi.domain.room.domain.RoomAccessType;
 import ei.algobaroapi.domain.room.domain.RoomStatus;
-import ei.algobaroapi.domain.room_member.dto.response.RoomMemberResponseDto;
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.util.ArrayList;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
@@ -51,28 +49,6 @@ public class RoomResponseDto {
     @Schema(description = "방 short UUID", example = "2ad2e9db")
     private String roomShortUuid;
 
-    @Schema(description = "방 참여자 정보", example =
-            """
-                    [
-                        {
-                            "id": "test1@test.com",
-                            "nickname": "test1",
-                            "profileImage": null,
-                            "role": "HOST",
-                            "joinTime": "2024-03-04T00:45:18",
-                            "ready": true
-                        },
-                        {
-                            "id": "test2@test.com",
-                            "nickname": "test2",
-                            "profileImage": null,
-                            "role": "PARTICIPANT",
-                            "joinTime": "2024-03-04T00:45:36",
-                            "ready": false
-                        }
-                    ]""")
-    private List<RoomMemberResponseDto> roomMembers;
-
     public static RoomResponseDto of(Room room) {
         return new RoomResponseDto(
                 room.getId(),
@@ -86,26 +62,7 @@ public class RoomResponseDto {
                 room.getRoomLimit(),
                 room.getTags(),
                 room.getTimeLimit(),
-                room.getRoomUuid().split("-")[0],
-                new ArrayList<>()
-        );
-    }
-
-    public static RoomResponseDto of(Room room, List<RoomMemberResponseDto> roomMembers) {
-        return new RoomResponseDto(
-                room.getId(),
-                room.getRoomStatus(),
-                room.getTitle(),
-                room.getIntroduce(),
-                room.getRoomAccessType(),
-                room.getProblemPlatform(),
-                room.getProblemName(),
-                room.getPassword(),
-                room.getRoomLimit(),
-                room.getTags(),
-                room.getTimeLimit(),
-                room.getRoomUuid().split("-")[0],
-                roomMembers
+                room.getRoomUuid().split("-")[0]
         );
     }
 }

--- a/src/main/java/ei/algobaroapi/domain/room/dto/response/RoomResponseDto.java
+++ b/src/main/java/ei/algobaroapi/domain/room/dto/response/RoomResponseDto.java
@@ -13,7 +13,7 @@ import lombok.Getter;
 @Getter
 @Builder
 @Schema(description = "메인 화면에 보여지는 방 정보")
-public class RoomDetailResponseDto {
+public class RoomResponseDto {
 
     @Schema(description = "방 번호", example = "1")
     private Long roomId;
@@ -73,9 +73,8 @@ public class RoomDetailResponseDto {
                     ]""")
     private List<RoomMemberResponseDto> roomMembers;
 
-
-    public static RoomDetailResponseDto of(Room room) {
-        return new RoomDetailResponseDto(
+    public static RoomResponseDto of(Room room) {
+        return new RoomResponseDto(
                 room.getId(),
                 room.getRoomStatus(),
                 room.getTitle(),
@@ -92,8 +91,8 @@ public class RoomDetailResponseDto {
         );
     }
 
-    public static RoomDetailResponseDto of(Room room, List<RoomMemberResponseDto> roomMembers) {
-        return new RoomDetailResponseDto(
+    public static RoomResponseDto of(Room room, List<RoomMemberResponseDto> roomMembers) {
+        return new RoomResponseDto(
                 room.getId(),
                 room.getRoomStatus(),
                 room.getTitle(),

--- a/src/main/java/ei/algobaroapi/domain/room/service/RoomService.java
+++ b/src/main/java/ei/algobaroapi/domain/room/service/RoomService.java
@@ -1,5 +1,6 @@
 package ei.algobaroapi.domain.room.service;
 
+import ei.algobaroapi.domain.member.domain.Member;
 import ei.algobaroapi.domain.room.dto.request.RoomCreateRequestDto;
 import ei.algobaroapi.domain.room.dto.request.RoomListRequestDto;
 import ei.algobaroapi.domain.room.dto.request.RoomUpdateRequestDto;
@@ -11,9 +12,10 @@ public interface RoomService {
 
     List<RoomDetailResponseDto> getAllRooms(RoomListRequestDto roomListRequestDto);
 
-    RoomDetailResponseDto createRoom(RoomCreateRequestDto roomCreateRequestDto);
+    RoomDetailResponseDto createRoom(RoomCreateRequestDto roomCreateRequestDto, Member member);
 
-    RoomDetailResponseDto updateRoomByRoomId(Long roomId, RoomUpdateRequestDto roomUpdateRequestDto);
+    RoomDetailResponseDto updateRoomByRoomId(Long roomId,
+            RoomUpdateRequestDto roomUpdateRequestDto);
 
     RoomDetailResponseDto getRoomByRoomUuid(String roomUuid);
 

--- a/src/main/java/ei/algobaroapi/domain/room/service/RoomService.java
+++ b/src/main/java/ei/algobaroapi/domain/room/service/RoomService.java
@@ -4,20 +4,20 @@ import ei.algobaroapi.domain.member.domain.Member;
 import ei.algobaroapi.domain.room.dto.request.RoomCreateRequestDto;
 import ei.algobaroapi.domain.room.dto.request.RoomListRequestDto;
 import ei.algobaroapi.domain.room.dto.request.RoomUpdateRequestDto;
-import ei.algobaroapi.domain.room.dto.response.RoomDetailResponseDto;
+import ei.algobaroapi.domain.room.dto.response.RoomResponseDto;
 import ei.algobaroapi.domain.room.dto.response.RoomSubmitCodeResponseDto;
 import java.util.List;
 
 public interface RoomService {
 
-    List<RoomDetailResponseDto> getAllRooms(RoomListRequestDto roomListRequestDto);
+    List<RoomResponseDto> getAllRooms(RoomListRequestDto roomListRequestDto);
 
-    RoomDetailResponseDto createRoom(RoomCreateRequestDto roomCreateRequestDto, Member member);
+    RoomResponseDto createRoom(RoomCreateRequestDto roomCreateRequestDto, Member member);
 
-    RoomDetailResponseDto updateRoomByRoomId(Long roomId,
+    RoomResponseDto updateRoomByRoomId(Long roomId,
             RoomUpdateRequestDto roomUpdateRequestDto);
 
-    RoomDetailResponseDto getRoomByRoomUuid(String roomUuid);
+    RoomResponseDto getRoomByRoomUuid(String roomUuid);
 
     void startCodingTest(Long roomId);
 

--- a/src/main/java/ei/algobaroapi/domain/room/service/RoomService.java
+++ b/src/main/java/ei/algobaroapi/domain/room/service/RoomService.java
@@ -4,6 +4,7 @@ import ei.algobaroapi.domain.member.domain.Member;
 import ei.algobaroapi.domain.room.dto.request.RoomCreateRequestDto;
 import ei.algobaroapi.domain.room.dto.request.RoomListRequestDto;
 import ei.algobaroapi.domain.room.dto.request.RoomUpdateRequestDto;
+import ei.algobaroapi.domain.room.dto.response.RoomDetailResponseDto;
 import ei.algobaroapi.domain.room.dto.response.RoomResponseDto;
 import ei.algobaroapi.domain.room.dto.response.RoomSubmitCodeResponseDto;
 import java.util.List;
@@ -12,12 +13,12 @@ public interface RoomService {
 
     List<RoomResponseDto> getAllRooms(RoomListRequestDto roomListRequestDto);
 
-    RoomResponseDto createRoom(RoomCreateRequestDto roomCreateRequestDto, Member member);
+    RoomDetailResponseDto createRoom(RoomCreateRequestDto roomCreateRequestDto, Member member);
 
     RoomResponseDto updateRoomByRoomId(Long roomId,
             RoomUpdateRequestDto roomUpdateRequestDto);
 
-    RoomResponseDto getRoomByRoomUuid(String roomUuid);
+    RoomDetailResponseDto getRoomByRoomUuid(String roomUuid);
 
     void startCodingTest(Long roomId);
 

--- a/src/main/java/ei/algobaroapi/domain/room/service/RoomServiceImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/room/service/RoomServiceImpl.java
@@ -6,6 +6,7 @@ import ei.algobaroapi.domain.room.domain.RoomRepository;
 import ei.algobaroapi.domain.room.dto.request.RoomCreateRequestDto;
 import ei.algobaroapi.domain.room.dto.request.RoomListRequestDto;
 import ei.algobaroapi.domain.room.dto.request.RoomUpdateRequestDto;
+import ei.algobaroapi.domain.room.dto.response.RoomDetailResponseDto;
 import ei.algobaroapi.domain.room.dto.response.RoomResponseDto;
 import ei.algobaroapi.domain.room.dto.response.RoomSubmitCodeResponseDto;
 import ei.algobaroapi.domain.room.exception.RoomNotFoundException;
@@ -39,14 +40,14 @@ public class RoomServiceImpl implements RoomService {
 
     @Override
     @Transactional
-    public RoomResponseDto createRoom(RoomCreateRequestDto roomCreateRequestDto,
+    public RoomDetailResponseDto createRoom(RoomCreateRequestDto roomCreateRequestDto,
             Member member) {
         Room createdRoom = roomRepository.save(roomCreateRequestDto.toEntity()); // DB 방 생성
 
         List<RoomMemberResponseDto> roomMembers = roomMemberService.createRoomByRoomId(createdRoom,
                 member);// DB RoomMember 방장 정보 생성
 
-        return RoomResponseDto.of(createdRoom, roomMembers);
+        return RoomDetailResponseDto.of(createdRoom, roomMembers);
     }
 
     @Override
@@ -62,11 +63,11 @@ public class RoomServiceImpl implements RoomService {
     }
 
     @Override
-    public RoomResponseDto getRoomByRoomUuid(String roomShortUuid) {
+    public RoomDetailResponseDto getRoomByRoomUuid(String roomShortUuid) {
         Room findRoom = roomRepository.findByRoomUuidStartingWith(roomShortUuid)
                 .orElseThrow(() -> RoomNotFoundException.of(RoomErrorCode.ROOM_NOT_FOUND));
 
-        return RoomResponseDto.of(findRoom, getRoomMembersByRoomId(findRoom.getId()));
+        return RoomDetailResponseDto.of(findRoom, getRoomMembersByRoomId(findRoom.getId()));
     }
 
     @Override

--- a/src/main/java/ei/algobaroapi/domain/room/service/RoomServiceImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/room/service/RoomServiceImpl.java
@@ -1,5 +1,6 @@
 package ei.algobaroapi.domain.room.service;
 
+import ei.algobaroapi.domain.member.domain.Member;
 import ei.algobaroapi.domain.room.domain.Room;
 import ei.algobaroapi.domain.room.domain.RoomRepository;
 import ei.algobaroapi.domain.room.dto.request.RoomCreateRequestDto;
@@ -9,6 +10,8 @@ import ei.algobaroapi.domain.room.dto.response.RoomDetailResponseDto;
 import ei.algobaroapi.domain.room.dto.response.RoomSubmitCodeResponseDto;
 import ei.algobaroapi.domain.room.exception.RoomNotFoundException;
 import ei.algobaroapi.domain.room.exception.common.RoomErrorCode;
+import ei.algobaroapi.domain.room_member.dto.response.RoomMemberResponseDto;
+import ei.algobaroapi.domain.room_member.service.RoomMemberService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -22,6 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class RoomServiceImpl implements RoomService {
 
     private final RoomRepository roomRepository;
+    private final RoomMemberService roomMemberService;
 
     @Override
     public List<RoomDetailResponseDto> getAllRooms(RoomListRequestDto roomListRequestDto) {
@@ -35,8 +39,14 @@ public class RoomServiceImpl implements RoomService {
 
     @Override
     @Transactional
-    public RoomDetailResponseDto createRoom(RoomCreateRequestDto roomCreateRequestDto) {
-        return RoomDetailResponseDto.of(roomRepository.save(roomCreateRequestDto.toEntity()));
+    public RoomDetailResponseDto createRoom(RoomCreateRequestDto roomCreateRequestDto,
+            Member member) {
+        Room createdRoom = roomRepository.save(roomCreateRequestDto.toEntity()); // DB 방 생성
+
+        List<RoomMemberResponseDto> roomMembers = roomMemberService.createRoomByRoomId(createdRoom,
+                member);// DB RoomMember 방장 정보 생성
+
+        return RoomDetailResponseDto.of(createdRoom, roomMembers);
     }
 
     @Override
@@ -53,8 +63,10 @@ public class RoomServiceImpl implements RoomService {
 
     @Override
     public RoomDetailResponseDto getRoomByRoomUuid(String roomShortUuid) {
-        return RoomDetailResponseDto.of(roomRepository.findByRoomUuidStartingWith(roomShortUuid)
-                .orElseThrow(() -> RoomNotFoundException.of(RoomErrorCode.ROOM_NOT_FOUND)));
+        Room findRoom = roomRepository.findByRoomUuidStartingWith(roomShortUuid)
+                .orElseThrow(() -> RoomNotFoundException.of(RoomErrorCode.ROOM_NOT_FOUND));
+
+        return RoomDetailResponseDto.of(findRoom, getRoomMembersByRoomId(findRoom.getId()));
     }
 
     @Override
@@ -66,5 +78,9 @@ public class RoomServiceImpl implements RoomService {
     public List<RoomSubmitCodeResponseDto> getSubmitCodesByRoomId(Long roomId) {
         // TODO: RoomMember 필드의 submitCode를 List로 반환
         return null;
+    }
+
+    private List<RoomMemberResponseDto> getRoomMembersByRoomId(Long roomId) {
+        return roomMemberService.getRoomMembersByRoomId(roomId);
     }
 }

--- a/src/main/java/ei/algobaroapi/domain/room/service/RoomServiceImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/room/service/RoomServiceImpl.java
@@ -6,7 +6,7 @@ import ei.algobaroapi.domain.room.domain.RoomRepository;
 import ei.algobaroapi.domain.room.dto.request.RoomCreateRequestDto;
 import ei.algobaroapi.domain.room.dto.request.RoomListRequestDto;
 import ei.algobaroapi.domain.room.dto.request.RoomUpdateRequestDto;
-import ei.algobaroapi.domain.room.dto.response.RoomDetailResponseDto;
+import ei.algobaroapi.domain.room.dto.response.RoomResponseDto;
 import ei.algobaroapi.domain.room.dto.response.RoomSubmitCodeResponseDto;
 import ei.algobaroapi.domain.room.exception.RoomNotFoundException;
 import ei.algobaroapi.domain.room.exception.common.RoomErrorCode;
@@ -28,45 +28,45 @@ public class RoomServiceImpl implements RoomService {
     private final RoomMemberService roomMemberService;
 
     @Override
-    public List<RoomDetailResponseDto> getAllRooms(RoomListRequestDto roomListRequestDto) {
+    public List<RoomResponseDto> getAllRooms(RoomListRequestDto roomListRequestDto) {
         Pageable pageable = PageRequest.of(roomListRequestDto.getPage(),
                 roomListRequestDto.getSize());
 
         return roomRepository.findAll(pageable).getContent().stream()
-                .map(RoomDetailResponseDto::of)
+                .map(RoomResponseDto::of)
                 .toList();
     }
 
     @Override
     @Transactional
-    public RoomDetailResponseDto createRoom(RoomCreateRequestDto roomCreateRequestDto,
+    public RoomResponseDto createRoom(RoomCreateRequestDto roomCreateRequestDto,
             Member member) {
         Room createdRoom = roomRepository.save(roomCreateRequestDto.toEntity()); // DB 방 생성
 
         List<RoomMemberResponseDto> roomMembers = roomMemberService.createRoomByRoomId(createdRoom,
                 member);// DB RoomMember 방장 정보 생성
 
-        return RoomDetailResponseDto.of(createdRoom, roomMembers);
+        return RoomResponseDto.of(createdRoom, roomMembers);
     }
 
     @Override
     @Transactional
-    public RoomDetailResponseDto updateRoomByRoomId(Long roomId,
+    public RoomResponseDto updateRoomByRoomId(Long roomId,
             RoomUpdateRequestDto roomUpdateRequestDto) {
         Room room = roomRepository.findById(roomId)
                 .orElseThrow(() -> RoomNotFoundException.of(RoomErrorCode.ROOM_NOT_FOUND));
 
         room.update(roomUpdateRequestDto);
 
-        return RoomDetailResponseDto.of(room);
+        return RoomResponseDto.of(room);
     }
 
     @Override
-    public RoomDetailResponseDto getRoomByRoomUuid(String roomShortUuid) {
+    public RoomResponseDto getRoomByRoomUuid(String roomShortUuid) {
         Room findRoom = roomRepository.findByRoomUuidStartingWith(roomShortUuid)
                 .orElseThrow(() -> RoomNotFoundException.of(RoomErrorCode.ROOM_NOT_FOUND));
 
-        return RoomDetailResponseDto.of(findRoom, getRoomMembersByRoomId(findRoom.getId()));
+        return RoomResponseDto.of(findRoom, getRoomMembersByRoomId(findRoom.getId()));
     }
 
     @Override

--- a/src/main/java/ei/algobaroapi/domain/room_member/controller/RoomMemberControllerDocImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/controller/RoomMemberControllerDocImpl.java
@@ -3,12 +3,16 @@ package ei.algobaroapi.domain.room_member.controller;
 import ei.algobaroapi.domain.member.domain.Member;
 import ei.algobaroapi.domain.room_member.domain.RoomMember;
 import ei.algobaroapi.domain.room_member.dto.response.RoomHostResponseDto;
+import ei.algobaroapi.domain.room_member.dto.response.RoomMemberResponseDto;
 import ei.algobaroapi.domain.room_member.service.RoomMemberService;
 import ei.algobaroapi.global.config.swaggerdoc.RoomMemberControllerDoc;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -20,10 +24,11 @@ public class RoomMemberControllerDocImpl implements RoomMemberControllerDoc {
     private final RoomMemberService roomMemberService;
 
     @Override
-    @GetMapping("/roomsTemp/{roomId}") // TODO: getRoomByUUID 와 Path가 겹쳐서 문제 발생, 임시로 변경 추후에 변경해야 함.
-    public void joinRoomByRoomId(@PathVariable(name = "roomId") Long roomId,
+    @PostMapping("/rooms-join/{roomId}")
+    @PreAuthorize("hasRole('USER')")
+    public List<RoomMemberResponseDto> joinRoomByRoomId(@PathVariable(name = "roomId") Long roomId,
             @AuthenticationPrincipal Member member) {
-
+        return roomMemberService.joinRoomByRoomId(roomId, member);
     }
 
     @Override

--- a/src/main/java/ei/algobaroapi/domain/room_member/domain/RoomMember.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/domain/RoomMember.java
@@ -15,6 +15,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -46,4 +47,13 @@ public class RoomMember extends BaseEntity {
 
     @Column(name = "submit_code")
     private String submitCode;
+
+    @Builder
+    public RoomMember(Room room, Member member, RoomMemberRole roomMemberRole, boolean isReady) {
+        this.room = room;
+        this.member = member;
+        this.roomMemberRole = roomMemberRole;
+        this.isReady = isReady;
+        this.submitCode = null;
+    }
 }

--- a/src/main/java/ei/algobaroapi/domain/room_member/domain/RoomMemberRepository.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/domain/RoomMemberRepository.java
@@ -1,0 +1,11 @@
+package ei.algobaroapi.domain.room_member.domain;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RoomMemberRepository extends JpaRepository<RoomMember, Long> {
+
+    List<RoomMember> findByRoomId(Long roomId);
+}

--- a/src/main/java/ei/algobaroapi/domain/room_member/dto/response/RoomMemberResponseDto.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/dto/response/RoomMemberResponseDto.java
@@ -1,0 +1,43 @@
+package ei.algobaroapi.domain.room_member.dto.response;
+
+import ei.algobaroapi.domain.room_member.domain.RoomMember;
+import ei.algobaroapi.domain.room_member.domain.RoomMemberRole;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "방 참여자 정보")
+public class RoomMemberResponseDto {
+
+    @Schema(description = "아이디", example = "test1@test.com")
+    private String id;
+
+    @Schema(description = "닉네임", example = "test1")
+    private String nickname;
+
+    @Schema(description = "회원 프로필 이미지", example = "https://image.url.com/test_profile_image")
+    private String profileImage;
+
+    @Schema(description = "준비 상태", example = "false")
+    private boolean isReady;
+
+    @Schema(description = "방장 여부", example = "HOST")
+    private RoomMemberRole role;
+
+    @Schema(description = "입장 시간", example = "2024-03-04 12:00:00")
+    private LocalDateTime joinTime;
+
+    public static RoomMemberResponseDto of(RoomMember roomMember) {
+        return RoomMemberResponseDto.builder()
+                .id(roomMember.getMember().getEmail().getEmail())
+                .nickname(roomMember.getMember().getNickname())
+                .profileImage(roomMember.getMember().getProfileImage())
+                .isReady(roomMember.isReady())
+                .role(roomMember.getRoomMemberRole())
+                .joinTime(roomMember.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberService.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberService.java
@@ -1,12 +1,19 @@
 package ei.algobaroapi.domain.room_member.service;
 
 import ei.algobaroapi.domain.member.domain.Member;
+import ei.algobaroapi.domain.room.domain.Room;
 import ei.algobaroapi.domain.room_member.domain.RoomMember;
 import ei.algobaroapi.domain.room_member.dto.response.RoomHostResponseDto;
+import ei.algobaroapi.domain.room_member.dto.response.RoomMemberResponseDto;
+import java.util.List;
 
 public interface RoomMemberService {
 
-    void joinRoomByRoomId(Long roomId, Member member);
+    List<RoomMemberResponseDto> createRoomByRoomId(Room room, Member member);
+
+    List<RoomMemberResponseDto> joinRoomByRoomId(Long roomId, Member member);
+
+    List<RoomMemberResponseDto> getRoomMembersByRoomId(Long roomId);
 
     RoomHostResponseDto changeHostManually(Long hostId, Long organizerId);
 

--- a/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberServiceImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberServiceImpl.java
@@ -1,18 +1,68 @@
 package ei.algobaroapi.domain.room_member.service;
 
 import ei.algobaroapi.domain.member.domain.Member;
+import ei.algobaroapi.domain.room.domain.Room;
+import ei.algobaroapi.domain.room.domain.RoomRepository;
+import ei.algobaroapi.domain.room.exception.RoomNotFoundException;
+import ei.algobaroapi.domain.room.exception.common.RoomErrorCode;
 import ei.algobaroapi.domain.room_member.domain.RoomMember;
+import ei.algobaroapi.domain.room_member.domain.RoomMemberRepository;
+import ei.algobaroapi.domain.room_member.domain.RoomMemberRole;
 import ei.algobaroapi.domain.room_member.dto.response.RoomHostResponseDto;
+import ei.algobaroapi.domain.room_member.dto.response.RoomMemberResponseDto;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class RoomMemberServiceImpl implements RoomMemberService {
 
-    @Override
-    public void joinRoomByRoomId(Long roomId, Member member) {
+    private final RoomRepository roomRepository;
+    private final RoomMemberRepository roomMemberRepository;
 
+    @Override
+    @Transactional
+    public List<RoomMemberResponseDto> createRoomByRoomId(Room room, Member member) {
+        RoomMember roomMember = RoomMember.builder()
+                .room(room)
+                .member(member)
+                .roomMemberRole(RoomMemberRole.HOST)
+                .isReady(true)
+                .build();
+
+        roomMemberRepository.save(roomMember);
+
+        return roomMemberRepository.findByRoomId(room.getId()).stream()
+                .map(RoomMemberResponseDto::of)
+                .toList();
+    }
+
+    @Override
+    @Transactional
+    public List<RoomMemberResponseDto> joinRoomByRoomId(Long roomId, Member member) {
+        RoomMember roomMember = RoomMember.builder()
+                .room(roomRepository.findById(roomId).orElseThrow(() -> RoomNotFoundException.of(
+                        RoomErrorCode.ROOM_NOT_FOUND)))
+                .member(member)
+                .roomMemberRole(RoomMemberRole.PARTICIPANT)
+                .isReady(false)
+                .build();
+
+        roomMemberRepository.save(roomMember);
+
+        return roomMemberRepository.findByRoomId(roomId).stream()
+                .map(RoomMemberResponseDto::of)
+                .toList();
+    }
+
+    @Override
+    public List<RoomMemberResponseDto> getRoomMembersByRoomId(Long roomId) {
+        return roomMemberRepository.findByRoomId(roomId).stream()
+                .map(RoomMemberResponseDto::of)
+                .toList();
     }
 
     @Override

--- a/src/main/java/ei/algobaroapi/global/config/swaggerdoc/RoomControllerDoc.java
+++ b/src/main/java/ei/algobaroapi/global/config/swaggerdoc/RoomControllerDoc.java
@@ -4,7 +4,7 @@ import ei.algobaroapi.domain.member.domain.Member;
 import ei.algobaroapi.domain.room.dto.request.RoomCreateRequestDto;
 import ei.algobaroapi.domain.room.dto.request.RoomListRequestDto;
 import ei.algobaroapi.domain.room.dto.request.RoomUpdateRequestDto;
-import ei.algobaroapi.domain.room.dto.response.RoomDetailResponseDto;
+import ei.algobaroapi.domain.room.dto.response.RoomResponseDto;
 import ei.algobaroapi.domain.room.dto.response.RoomSubmitCodeResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -17,20 +17,20 @@ public interface RoomControllerDoc {
 
     @Operation(summary = "모든 방 정보 조회", description = "현재 존재하는 모든 방 정보를 조회합니다.")
     @ApiResponse(responseCode = "200", description = "방 정보 조회 성공")
-    List<RoomDetailResponseDto> getAllRooms(RoomListRequestDto roomListRequestDto);
+    List<RoomResponseDto> getAllRooms(RoomListRequestDto roomListRequestDto);
 
     @Operation(summary = "방 생성", description = "새로운 방을 생성합니다.")
     @ApiResponse(responseCode = "200", description = "방 생성 성공")
-    RoomDetailResponseDto createRoom(RoomCreateRequestDto roomCreateRequestDto, Member member);
+    RoomResponseDto createRoom(RoomCreateRequestDto roomCreateRequestDto, Member member);
 
     @Operation(summary = "방 수정", description = "방 정보를 수정합니다.")
     @ApiResponse(responseCode = "200", description = "방 수정 성공")
     @ApiResponse(responseCode = "E03301", description = "수정하려는 방 정보를 찾지 못했습니다.")
-    RoomDetailResponseDto updateRoomById(Long roomId, RoomUpdateRequestDto roomUpdateRequestDto);
+    RoomResponseDto updateRoomById(Long roomId, RoomUpdateRequestDto roomUpdateRequestDto);
 
     @Operation(summary = "개별 방 정보 조회", description = "short UUID를 통해 방을 조회합니다.")
     @ApiResponse(responseCode = "200", description = "방 정보 조회 성공")
-    RoomDetailResponseDto getRoomByShortUuid(String roomShortUuid);
+    RoomResponseDto getRoomByShortUuid(String roomShortUuid);
 
     @Operation(summary = "문제 풀이 시작 - 작업 중", description = "코딩테스트를 시작합니다.")
     @ApiResponse(responseCode = "200", description = "풀이 시작 성공")

--- a/src/main/java/ei/algobaroapi/global/config/swaggerdoc/RoomControllerDoc.java
+++ b/src/main/java/ei/algobaroapi/global/config/swaggerdoc/RoomControllerDoc.java
@@ -1,5 +1,6 @@
 package ei.algobaroapi.global.config.swaggerdoc;
 
+import ei.algobaroapi.domain.member.domain.Member;
 import ei.algobaroapi.domain.room.dto.request.RoomCreateRequestDto;
 import ei.algobaroapi.domain.room.dto.request.RoomListRequestDto;
 import ei.algobaroapi.domain.room.dto.request.RoomUpdateRequestDto;
@@ -20,7 +21,7 @@ public interface RoomControllerDoc {
 
     @Operation(summary = "방 생성", description = "새로운 방을 생성합니다.")
     @ApiResponse(responseCode = "200", description = "방 생성 성공")
-    RoomDetailResponseDto createRoom(RoomCreateRequestDto roomCreateRequestDto);
+    RoomDetailResponseDto createRoom(RoomCreateRequestDto roomCreateRequestDto, Member member);
 
     @Operation(summary = "방 수정", description = "방 정보를 수정합니다.")
     @ApiResponse(responseCode = "200", description = "방 수정 성공")

--- a/src/main/java/ei/algobaroapi/global/config/swaggerdoc/RoomControllerDoc.java
+++ b/src/main/java/ei/algobaroapi/global/config/swaggerdoc/RoomControllerDoc.java
@@ -4,6 +4,7 @@ import ei.algobaroapi.domain.member.domain.Member;
 import ei.algobaroapi.domain.room.dto.request.RoomCreateRequestDto;
 import ei.algobaroapi.domain.room.dto.request.RoomListRequestDto;
 import ei.algobaroapi.domain.room.dto.request.RoomUpdateRequestDto;
+import ei.algobaroapi.domain.room.dto.response.RoomDetailResponseDto;
 import ei.algobaroapi.domain.room.dto.response.RoomResponseDto;
 import ei.algobaroapi.domain.room.dto.response.RoomSubmitCodeResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
@@ -21,7 +22,7 @@ public interface RoomControllerDoc {
 
     @Operation(summary = "방 생성", description = "새로운 방을 생성합니다.")
     @ApiResponse(responseCode = "200", description = "방 생성 성공")
-    RoomResponseDto createRoom(RoomCreateRequestDto roomCreateRequestDto, Member member);
+    RoomDetailResponseDto createRoom(RoomCreateRequestDto roomCreateRequestDto, Member member);
 
     @Operation(summary = "방 수정", description = "방 정보를 수정합니다.")
     @ApiResponse(responseCode = "200", description = "방 수정 성공")
@@ -30,7 +31,7 @@ public interface RoomControllerDoc {
 
     @Operation(summary = "개별 방 정보 조회", description = "short UUID를 통해 방을 조회합니다.")
     @ApiResponse(responseCode = "200", description = "방 정보 조회 성공")
-    RoomResponseDto getRoomByShortUuid(String roomShortUuid);
+    RoomDetailResponseDto getRoomByShortUuid(String roomShortUuid);
 
     @Operation(summary = "문제 풀이 시작 - 작업 중", description = "코딩테스트를 시작합니다.")
     @ApiResponse(responseCode = "200", description = "풀이 시작 성공")

--- a/src/main/java/ei/algobaroapi/global/config/swaggerdoc/RoomMemberControllerDoc.java
+++ b/src/main/java/ei/algobaroapi/global/config/swaggerdoc/RoomMemberControllerDoc.java
@@ -3,17 +3,19 @@ package ei.algobaroapi.global.config.swaggerdoc;
 import ei.algobaroapi.domain.member.domain.Member;
 import ei.algobaroapi.domain.room_member.domain.RoomMember;
 import ei.algobaroapi.domain.room_member.dto.response.RoomHostResponseDto;
+import ei.algobaroapi.domain.room_member.dto.response.RoomMemberResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 
 @Tag(name = "RoomMember", description = "방-회원 관련 API")
 @SuppressWarnings("unused")
 public interface RoomMemberControllerDoc {
 
-    @Operation(summary = "방 참여 - 작업 중", description = "생성된 방에 참여합니다.")
+    @Operation(summary = "방 참여", description = "생성된 방에 참여합니다.")
     @ApiResponse(responseCode = "200", description = "방 참여에 성공하였습니다.")
-    void joinRoomByRoomId(Long roomId, Member member);
+    List<RoomMemberResponseDto> joinRoomByRoomId(Long roomId, Member member);
 
     @Operation(summary = "방장 수동 변경 - 작업 중", description = "현재 방장이 참여자에게 방장 권한을 위임합니다.")
     @ApiResponse(responseCode = "200", description = "방장 수동 위임에 성공하였습니다.")


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

방 참여 로직을 추가하였습니다.
방 생성과 방 참여 로직을 구분하여 구현을 진행했습니다.

## 💬리뷰 시 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

방 생성 사이클을 보면서 로직을 구현하였습니다. 
흐름 전체가 하나의 로직이기 때문에 세세하게 봐주시면 감사하겠습니다! 👍 


해결했습니다.
RoomDetailResponseDto -> RoomResponseDto(참여자 정보 미포함), RoomDetailResponseDto(참여자 정보 포함)
~~~ 현재 하나의 RoomDetailResponseDto 를 사용하여 2가지 경우를 호출하고 있는데 
- 방 참여 인원을 포함하지 않는 경우(페이징을 통한 방 전체 조회, 방 업데이트)
- 방 참여 인원을 포함하는 경우(uuid를 통한 조회 ..)

해당 dto를 2가지로 분리하는 방법이 좋다고 생각하는데 의견이 궁금하여 질문드립니다! 

