### PR TITLE
준비 상태 변경 기능 구현

### DIFF
--- a/src/main/java/ei/algobaroapi/domain/room_member/controller/RoomMemberControllerDocImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/controller/RoomMemberControllerDocImpl.java
@@ -32,6 +32,14 @@ public class RoomMemberControllerDocImpl implements RoomMemberControllerDoc {
     }
 
     @Override
+    @PostMapping("/rooms-ready/{roomId}")
+    @PreAuthorize("hasRole('USER')")
+    public RoomMemberResponseDto changeReadyStatus(@PathVariable(name = "roomId") Long roomId,
+            @AuthenticationPrincipal Member member) {
+        return roomMemberService.changeReadyStatus(roomId, member.getId());
+    }
+
+    @Override
     @GetMapping("/rooms/host/{hostId}/{organizerId}")
     public RoomHostResponseDto changeHostManually(@PathVariable(name = "hostId") Long hostId,
             @PathVariable(name = "organizerId") Long organizerId) {

--- a/src/main/java/ei/algobaroapi/domain/room_member/domain/RoomMember.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/domain/RoomMember.java
@@ -56,4 +56,8 @@ public class RoomMember extends BaseEntity {
         this.isReady = isReady;
         this.submitCode = null;
     }
+
+    public void changeReadyStatus() {
+        this.isReady = !this.isReady;
+    }
 }

--- a/src/main/java/ei/algobaroapi/domain/room_member/domain/RoomMemberRepository.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/domain/RoomMemberRepository.java
@@ -1,11 +1,16 @@
 package ei.algobaroapi.domain.room_member.domain;
 
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface RoomMemberRepository extends JpaRepository<RoomMember, Long> {
 
     List<RoomMember> findByRoomId(Long roomId);
+
+    @Query("select rm from RoomMember rm where rm.room.id = :roomId and rm.member.id = :id")
+    Optional<RoomMember> findRoomMemberByRoomIdAndMemberId(Long roomId, Long id);
 }

--- a/src/main/java/ei/algobaroapi/domain/room_member/exception/RoomMemberNotFoundException.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/exception/RoomMemberNotFoundException.java
@@ -1,0 +1,20 @@
+package ei.algobaroapi.domain.room_member.exception;
+
+import ei.algobaroapi.domain.room_member.exception.common.RoomMemberErrorCode;
+import lombok.Getter;
+
+@Getter
+public class RoomMemberNotFoundException extends RuntimeException {
+
+    private final String errorCode;
+    private final String errorMessage;
+
+    private RoomMemberNotFoundException(RoomMemberErrorCode errorCode) {
+        this.errorCode = errorCode.getErrorCode();
+        this.errorMessage = errorCode.getErrorMessage();
+    }
+
+    public static RoomMemberNotFoundException of(RoomMemberErrorCode errorCode) {
+        return new RoomMemberNotFoundException(errorCode);
+    }
+}

--- a/src/main/java/ei/algobaroapi/domain/room_member/exception/common/RoomMemberErrorCode.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/exception/common/RoomMemberErrorCode.java
@@ -1,0 +1,14 @@
+package ei.algobaroapi.domain.room_member.exception.common;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum RoomMemberErrorCode {
+
+    ROOM_MEMBER_ERROR_CODE("E05301", "해당 방에 멤버를 찾지 못했습니다.");
+
+    private final String errorCode;
+    private final String errorMessage;
+}

--- a/src/main/java/ei/algobaroapi/domain/room_member/exception/common/RoomMemberExceptionHandler.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/exception/common/RoomMemberExceptionHandler.java
@@ -1,0 +1,21 @@
+package ei.algobaroapi.domain.room_member.exception.common;
+
+import ei.algobaroapi.domain.room_member.exception.RoomMemberNotFoundException;
+import ei.algobaroapi.global.response.message.ErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class RoomMemberExceptionHandler {
+
+    @ExceptionHandler(RoomMemberNotFoundException.class)
+    public ResponseEntity<ErrorResponse> catchRoomMemberNotFountException(RoomMemberNotFoundException e) {
+        log.warn(e.getErrorMessage());
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ErrorResponse.of(e.getErrorCode(), e.getErrorMessage()));
+    }
+}

--- a/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberService.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberService.java
@@ -15,6 +15,8 @@ public interface RoomMemberService {
 
     List<RoomMemberResponseDto> getRoomMembersByRoomId(Long roomId);
 
+    RoomMemberResponseDto changeReadyStatus(Long roomId, Long memberId);
+
     RoomHostResponseDto changeHostManually(Long hostId, Long organizerId);
 
     RoomHostResponseDto changeHostAutomatically(RoomMember roomMember);

--- a/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberServiceImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberServiceImpl.java
@@ -10,6 +10,8 @@ import ei.algobaroapi.domain.room_member.domain.RoomMemberRepository;
 import ei.algobaroapi.domain.room_member.domain.RoomMemberRole;
 import ei.algobaroapi.domain.room_member.dto.response.RoomHostResponseDto;
 import ei.algobaroapi.domain.room_member.dto.response.RoomMemberResponseDto;
+import ei.algobaroapi.domain.room_member.exception.RoomMemberNotFoundException;
+import ei.algobaroapi.domain.room_member.exception.common.RoomMemberErrorCode;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -63,6 +65,19 @@ public class RoomMemberServiceImpl implements RoomMemberService {
         return roomMemberRepository.findByRoomId(roomId).stream()
                 .map(RoomMemberResponseDto::of)
                 .toList();
+    }
+
+    @Override
+    @Transactional
+    public RoomMemberResponseDto changeReadyStatus(Long roomId, Long memberId) {
+        RoomMember roomMember = roomMemberRepository.findRoomMemberByRoomIdAndMemberId(roomId,
+                        memberId)
+                .orElseThrow(() -> RoomMemberNotFoundException.of(
+                        RoomMemberErrorCode.ROOM_MEMBER_ERROR_CODE));
+
+        roomMember.changeReadyStatus();
+
+        return RoomMemberResponseDto.of(roomMember);
     }
 
     @Override

--- a/src/main/java/ei/algobaroapi/global/config/swaggerdoc/RoomMemberControllerDoc.java
+++ b/src/main/java/ei/algobaroapi/global/config/swaggerdoc/RoomMemberControllerDoc.java
@@ -17,6 +17,10 @@ public interface RoomMemberControllerDoc {
     @ApiResponse(responseCode = "200", description = "방 참여에 성공하였습니다.")
     List<RoomMemberResponseDto> joinRoomByRoomId(Long roomId, Member member);
 
+    @Operation(summary = "준비 상태 변경", description = "방 참여자의 준비 상태를 변경합니다. true -> false, false -> true")
+    @ApiResponse(responseCode = "200", description = "준비 상태 변경에 성공하였습니다.")
+    RoomMemberResponseDto changeReadyStatus(Long roomId, Member member);
+
     @Operation(summary = "방장 수동 변경 - 작업 중", description = "현재 방장이 참여자에게 방장 권한을 위임합니다.")
     @ApiResponse(responseCode = "200", description = "방장 수동 위임에 성공하였습니다.")
     RoomHostResponseDto changeHostManually(Long hostId, Long organizerId);

--- a/src/main/java/ei/algobaroapi/global/config/swaggerdoc/RoomMemberControllerDoc.java
+++ b/src/main/java/ei/algobaroapi/global/config/swaggerdoc/RoomMemberControllerDoc.java
@@ -19,6 +19,7 @@ public interface RoomMemberControllerDoc {
 
     @Operation(summary = "준비 상태 변경", description = "방 참여자의 준비 상태를 변경합니다. true -> false, false -> true")
     @ApiResponse(responseCode = "200", description = "준비 상태 변경에 성공하였습니다.")
+    @ApiResponse(responseCode = "E05301", description = "해당 방에 멤버를 찾지 못했습니다.")
     RoomMemberResponseDto changeReadyStatus(Long roomId, Member member);
 
     @Operation(summary = "방장 수동 변경 - 작업 중", description = "현재 방장이 참여자에게 방장 권한을 위임합니다.")


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

- 준비 상태 변경 메서드 및 API 구현
- RoomMemberNotFound 예외 처리 

## 💬리뷰 시 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

방장은 방을 생성할 때 isReady 필드가 true
참여자는 방 참여할 때 isReady 필드가 false로 초기화됩니다.

해당 준비 상태 변경은 참여자를 기준으로 만들었으며
UI 측면에서 방장은 시작 버튼이, 참여자는 준비 버튼이 되어있을 것이라 생각하고 구현하였습니다.
