### PR TITLE
방장 자동 변경 기능 및 리팩토링

### DIFF
--- a/src/main/java/ei/algobaroapi/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/member/service/MemberServiceImpl.java
@@ -44,6 +44,7 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
+    @Transactional
     public void updateMemberDetail(Long id, MemberDetailUpdateRequest request) {
         Member findMember = this.getMemberById(id);
 

--- a/src/main/java/ei/algobaroapi/domain/room_member/controller/RoomMemberControllerDocImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/controller/RoomMemberControllerDocImpl.java
@@ -1,9 +1,10 @@
 package ei.algobaroapi.domain.room_member.controller;
 
 import ei.algobaroapi.domain.member.domain.Member;
-import ei.algobaroapi.domain.room_member.domain.RoomMember;
+import ei.algobaroapi.domain.room_member.dto.request.HostAutoChangeRequestDto;
 import ei.algobaroapi.domain.room_member.dto.request.HostChangeRequestDto;
 import ei.algobaroapi.domain.room_member.dto.request.JoinRoomRequestDto;
+import ei.algobaroapi.domain.room_member.dto.response.RoomHostDto;
 import ei.algobaroapi.domain.room_member.dto.response.RoomHostResponseDto;
 import ei.algobaroapi.domain.room_member.dto.response.RoomMemberResponseDto;
 import ei.algobaroapi.domain.room_member.service.RoomMemberService;
@@ -50,7 +51,8 @@ public class RoomMemberControllerDocImpl implements RoomMemberControllerDoc {
 
     @Override
     @PostMapping("/rooms/auto-change-host")
-    public RoomHostResponseDto changeHostAutomatically(RoomMember roomMember) {
-        return null;
+    public RoomHostDto changeHostAutomatically(
+            @RequestBody HostAutoChangeRequestDto hostAutoChangeRequestDto) {
+        return roomMemberService.changeHostAutomatically(hostAutoChangeRequestDto);
     }
 }

--- a/src/main/java/ei/algobaroapi/domain/room_member/controller/RoomMemberControllerDocImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/controller/RoomMemberControllerDocImpl.java
@@ -2,7 +2,7 @@ package ei.algobaroapi.domain.room_member.controller;
 
 import ei.algobaroapi.domain.member.domain.Member;
 import ei.algobaroapi.domain.room_member.dto.request.HostAutoChangeRequestDto;
-import ei.algobaroapi.domain.room_member.dto.request.HostChangeRequestDto;
+import ei.algobaroapi.domain.room_member.dto.request.HostManualChangeRequestDto;
 import ei.algobaroapi.domain.room_member.dto.request.JoinRoomRequestDto;
 import ei.algobaroapi.domain.room_member.dto.response.RoomHostAutoChangeResponseDto;
 import ei.algobaroapi.domain.room_member.dto.response.RoomHostResponseDto;
@@ -45,8 +45,8 @@ public class RoomMemberControllerDocImpl implements RoomMemberControllerDoc {
     @Override
     @PostMapping("/rooms/manual-change-host")
     public RoomHostResponseDto changeHostManually(
-            @RequestBody HostChangeRequestDto hostChangeRequestDto) {
-        return roomMemberService.changeHostManually(hostChangeRequestDto);
+            @RequestBody HostManualChangeRequestDto hostManualChangeRequestDto) {
+        return roomMemberService.changeHostManually(hostManualChangeRequestDto);
     }
 
     @Override

--- a/src/main/java/ei/algobaroapi/domain/room_member/controller/RoomMemberControllerDocImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/controller/RoomMemberControllerDocImpl.java
@@ -4,7 +4,7 @@ import ei.algobaroapi.domain.member.domain.Member;
 import ei.algobaroapi.domain.room_member.dto.request.HostAutoChangeRequestDto;
 import ei.algobaroapi.domain.room_member.dto.request.HostChangeRequestDto;
 import ei.algobaroapi.domain.room_member.dto.request.JoinRoomRequestDto;
-import ei.algobaroapi.domain.room_member.dto.response.RoomHostDto;
+import ei.algobaroapi.domain.room_member.dto.response.RoomHostAutoChangeResponseDto;
 import ei.algobaroapi.domain.room_member.dto.response.RoomHostResponseDto;
 import ei.algobaroapi.domain.room_member.dto.response.RoomMemberResponseDto;
 import ei.algobaroapi.domain.room_member.service.RoomMemberService;
@@ -51,7 +51,7 @@ public class RoomMemberControllerDocImpl implements RoomMemberControllerDoc {
 
     @Override
     @PostMapping("/rooms/auto-change-host")
-    public RoomHostDto changeHostAutomatically(
+    public RoomHostAutoChangeResponseDto changeHostAutomatically(
             @RequestBody HostAutoChangeRequestDto hostAutoChangeRequestDto) {
         return roomMemberService.changeHostAutomatically(hostAutoChangeRequestDto);
     }

--- a/src/main/java/ei/algobaroapi/domain/room_member/controller/RoomMemberControllerDocImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/controller/RoomMemberControllerDocImpl.java
@@ -5,7 +5,7 @@ import ei.algobaroapi.domain.room_member.dto.request.HostAutoChangeRequestDto;
 import ei.algobaroapi.domain.room_member.dto.request.HostManualChangeRequestDto;
 import ei.algobaroapi.domain.room_member.dto.request.JoinRoomRequestDto;
 import ei.algobaroapi.domain.room_member.dto.response.RoomHostAutoChangeResponseDto;
-import ei.algobaroapi.domain.room_member.dto.response.RoomHostResponseDto;
+import ei.algobaroapi.domain.room_member.dto.response.RoomHostManualResponseDto;
 import ei.algobaroapi.domain.room_member.dto.response.RoomMemberResponseDto;
 import ei.algobaroapi.domain.room_member.service.RoomMemberService;
 import ei.algobaroapi.global.config.swaggerdoc.RoomMemberControllerDoc;
@@ -44,7 +44,7 @@ public class RoomMemberControllerDocImpl implements RoomMemberControllerDoc {
 
     @Override
     @PostMapping("/rooms/manual-change-host")
-    public RoomHostResponseDto changeHostManually(
+    public RoomHostManualResponseDto changeHostManually(
             @RequestBody HostManualChangeRequestDto hostManualChangeRequestDto) {
         return roomMemberService.changeHostManually(hostManualChangeRequestDto);
     }

--- a/src/main/java/ei/algobaroapi/domain/room_member/domain/RoomMember.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/domain/RoomMember.java
@@ -57,14 +57,14 @@ public class RoomMember extends BaseEntity {
         this.submitCode = null;
     }
 
-    public void changeRole(RoomMemberRole roomMemberRole) {
-        if (roomMemberRole == RoomMemberRole.HOST) {
-            this.roomMemberRole = roomMemberRole;
-            this.isReady = true; // 방장은 언제나 준비 상태
-        } else {
-            this.roomMemberRole = roomMemberRole;
-            this.isReady = false; // 참여자 기본값은 준비 안됨
-        }
+    public void changeRoleToHost() {
+        this.roomMemberRole = RoomMemberRole.HOST;
+        this.isReady = true;
+    }
+
+    public void changeRoleToParticipant() {
+        this.roomMemberRole = RoomMemberRole.PARTICIPANT;
+        this.isReady = false;
     }
 
     public void changeReadyStatus() {

--- a/src/main/java/ei/algobaroapi/domain/room_member/domain/RoomMember.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/domain/RoomMember.java
@@ -70,4 +70,8 @@ public class RoomMember extends BaseEntity {
     public void changeReadyStatus() {
         this.isReady = !this.isReady;
     }
+
+    public boolean isParticipant() {
+        return this.roomMemberRole == RoomMemberRole.PARTICIPANT;
+    }
 }

--- a/src/main/java/ei/algobaroapi/domain/room_member/dto/request/HostAutoChangeRequestDto.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/dto/request/HostAutoChangeRequestDto.java
@@ -1,17 +1,18 @@
 package ei.algobaroapi.domain.room_member.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
 @Schema(description = "방장 자동 변경 요청 정보")
+@NoArgsConstructor
+@AllArgsConstructor
 public class HostAutoChangeRequestDto {
 
     @Schema(description = "방 번호", example = "4")
     private Long roomId;
-
-    @Schema(description = "현재 방장 번호", example = "1")
-    private Long hostId;
 }

--- a/src/main/java/ei/algobaroapi/domain/room_member/dto/request/HostAutoChangeRequestDto.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/dto/request/HostAutoChangeRequestDto.java
@@ -1,0 +1,17 @@
+package ei.algobaroapi.domain.room_member.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "방장 자동 변경 요청 정보")
+public class HostAutoChangeRequestDto {
+
+    @Schema(description = "방 번호", example = "4")
+    private Long roomId;
+
+    @Schema(description = "현재 방장 번호", example = "1")
+    private Long hostId;
+}

--- a/src/main/java/ei/algobaroapi/domain/room_member/dto/request/HostManualChangeRequestDto.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/dto/request/HostManualChangeRequestDto.java
@@ -6,7 +6,8 @@ import lombok.Getter;
 
 @Getter
 @Builder
-public class HostChangeRequestDto {
+@Schema(description = "방장 수동 변경 요청 정보")
+public class HostManualChangeRequestDto {
 
     @Schema(description = "방 번호", example = "4")
     private Long roomId;

--- a/src/main/java/ei/algobaroapi/domain/room_member/dto/request/JoinRoomRequestDto.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/dto/request/JoinRoomRequestDto.java
@@ -1,11 +1,16 @@
 package ei.algobaroapi.domain.room_member.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
+@Schema(description = "방 참여 요청 정보")
+@NoArgsConstructor
+@AllArgsConstructor
 public class JoinRoomRequestDto {
 
     @Schema(description = "방 비밀번호", example = "password1234")

--- a/src/main/java/ei/algobaroapi/domain/room_member/dto/response/RoomHostAutoChangeResponseDto.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/dto/response/RoomHostAutoChangeResponseDto.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 @Getter
 @Builder
 @Schema(description = "방 방장 자동 변경 정보")
-public class RoomHostDto {
+public class RoomHostAutoChangeResponseDto {
 
     @Schema(description = "방 번호", example = "30")
     private Long roomId;
@@ -19,8 +19,8 @@ public class RoomHostDto {
     @Schema(description = "현재 방장의 닉네임", example = "test2")
     private String newHostNickname;
 
-    public static RoomHostDto of(Long roomId, RoomMember newHost) {
-        return RoomHostDto.builder()
+    public static RoomHostAutoChangeResponseDto of(Long roomId, RoomMember newHost) {
+        return RoomHostAutoChangeResponseDto.builder()
                 .roomId(roomId)
                 .newHostId(newHost.getId())
                 .newHostNickname(newHost.getMember().getNickname())

--- a/src/main/java/ei/algobaroapi/domain/room_member/dto/response/RoomHostDto.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/dto/response/RoomHostDto.java
@@ -1,0 +1,29 @@
+package ei.algobaroapi.domain.room_member.dto.response;
+
+import ei.algobaroapi.domain.room_member.domain.RoomMember;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@Schema(description = "방 방장 자동 변경 정보")
+public class RoomHostDto {
+
+    @Schema(description = "방 번호", example = "30")
+    private Long roomId;
+
+    @Schema(description = "현재 방장의 방-멤버 번호", example = "2")
+    private Long newHostId;
+
+    @Schema(description = "현재 방장의 닉네임", example = "test2")
+    private String newHostNickname;
+
+    public static RoomHostDto of(Long roomId, RoomMember newHost) {
+        return RoomHostDto.builder()
+                .roomId(roomId)
+                .newHostId(newHost.getId())
+                .newHostNickname(newHost.getMember().getNickname())
+                .build();
+    }
+}

--- a/src/main/java/ei/algobaroapi/domain/room_member/dto/response/RoomHostManualResponseDto.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/dto/response/RoomHostManualResponseDto.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 @Getter
 @Builder
 @Schema(description = "방 방장 정보")
-public class RoomHostResponseDto {
+public class RoomHostManualResponseDto {
 
     @Schema(description = "방 번호", example = "30")
     private Long roomId;
@@ -25,8 +25,8 @@ public class RoomHostResponseDto {
     @Schema(description = "현재 방장의 닉네임", example = "test2")
     private String newHostNickname;
 
-    public static RoomHostResponseDto of(Long roomId, RoomMember previousHost, RoomMember newHost) {
-        return RoomHostResponseDto.builder()
+    public static RoomHostManualResponseDto of(Long roomId, RoomMember previousHost, RoomMember newHost) {
+        return RoomHostManualResponseDto.builder()
                 .roomId(roomId)
                 .previousHostId(previousHost.getId())
                 .previousHostNickname(previousHost.getMember().getNickname())

--- a/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberService.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberService.java
@@ -4,7 +4,7 @@ import ei.algobaroapi.domain.member.domain.Member;
 import ei.algobaroapi.domain.room.domain.Room;
 import ei.algobaroapi.domain.room_member.domain.RoomMember;
 import ei.algobaroapi.domain.room_member.dto.request.HostAutoChangeRequestDto;
-import ei.algobaroapi.domain.room_member.dto.request.HostChangeRequestDto;
+import ei.algobaroapi.domain.room_member.dto.request.HostManualChangeRequestDto;
 import ei.algobaroapi.domain.room_member.dto.response.RoomHostAutoChangeResponseDto;
 import ei.algobaroapi.domain.room_member.dto.response.RoomHostResponseDto;
 import ei.algobaroapi.domain.room_member.dto.response.RoomMemberResponseDto;
@@ -20,7 +20,7 @@ public interface RoomMemberService {
 
     RoomMemberResponseDto changeReadyStatus(Long roomId, Long memberId);
 
-    RoomHostResponseDto changeHostManually(HostChangeRequestDto hostChangeRequestDto);
+    RoomHostResponseDto changeHostManually(HostManualChangeRequestDto hostManualChangeRequestDto);
 
     RoomHostAutoChangeResponseDto changeHostAutomatically(HostAutoChangeRequestDto hostAutoChangeRequestDto);
 

--- a/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberService.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberService.java
@@ -3,7 +3,9 @@ package ei.algobaroapi.domain.room_member.service;
 import ei.algobaroapi.domain.member.domain.Member;
 import ei.algobaroapi.domain.room.domain.Room;
 import ei.algobaroapi.domain.room_member.domain.RoomMember;
+import ei.algobaroapi.domain.room_member.dto.request.HostAutoChangeRequestDto;
 import ei.algobaroapi.domain.room_member.dto.request.HostChangeRequestDto;
+import ei.algobaroapi.domain.room_member.dto.response.RoomHostDto;
 import ei.algobaroapi.domain.room_member.dto.response.RoomHostResponseDto;
 import ei.algobaroapi.domain.room_member.dto.response.RoomMemberResponseDto;
 import java.util.List;
@@ -20,7 +22,7 @@ public interface RoomMemberService {
 
     RoomMemberResponseDto changeReadyStatus(Long roomId, Long memberId);
 
-    RoomHostResponseDto changeHostAutomatically(RoomMember roomMember);
+    RoomHostDto changeHostAutomatically(HostAutoChangeRequestDto hostAutoChangeRequestDto);
 
     List<RoomMember> getByRoomIdAllReady(Long roomId);
 

--- a/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberService.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberService.java
@@ -18,9 +18,9 @@ public interface RoomMemberService {
 
     List<RoomMemberResponseDto> getRoomMembersByRoomId(Long roomId);
 
-    RoomHostResponseDto changeHostManually(HostChangeRequestDto hostChangeRequestDto);
-
     RoomMemberResponseDto changeReadyStatus(Long roomId, Long memberId);
+
+    RoomHostResponseDto changeHostManually(HostChangeRequestDto hostChangeRequestDto);
 
     RoomHostDto changeHostAutomatically(HostAutoChangeRequestDto hostAutoChangeRequestDto);
 

--- a/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberService.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberService.java
@@ -6,7 +6,7 @@ import ei.algobaroapi.domain.room_member.domain.RoomMember;
 import ei.algobaroapi.domain.room_member.dto.request.HostAutoChangeRequestDto;
 import ei.algobaroapi.domain.room_member.dto.request.HostManualChangeRequestDto;
 import ei.algobaroapi.domain.room_member.dto.response.RoomHostAutoChangeResponseDto;
-import ei.algobaroapi.domain.room_member.dto.response.RoomHostResponseDto;
+import ei.algobaroapi.domain.room_member.dto.response.RoomHostManualResponseDto;
 import ei.algobaroapi.domain.room_member.dto.response.RoomMemberResponseDto;
 import java.util.List;
 
@@ -20,7 +20,7 @@ public interface RoomMemberService {
 
     RoomMemberResponseDto changeReadyStatus(Long roomId, Long memberId);
 
-    RoomHostResponseDto changeHostManually(HostManualChangeRequestDto hostManualChangeRequestDto);
+    RoomHostManualResponseDto changeHostManually(HostManualChangeRequestDto hostManualChangeRequestDto);
 
     RoomHostAutoChangeResponseDto changeHostAutomatically(HostAutoChangeRequestDto hostAutoChangeRequestDto);
 

--- a/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberService.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberService.java
@@ -5,7 +5,7 @@ import ei.algobaroapi.domain.room.domain.Room;
 import ei.algobaroapi.domain.room_member.domain.RoomMember;
 import ei.algobaroapi.domain.room_member.dto.request.HostAutoChangeRequestDto;
 import ei.algobaroapi.domain.room_member.dto.request.HostChangeRequestDto;
-import ei.algobaroapi.domain.room_member.dto.response.RoomHostDto;
+import ei.algobaroapi.domain.room_member.dto.response.RoomHostAutoChangeResponseDto;
 import ei.algobaroapi.domain.room_member.dto.response.RoomHostResponseDto;
 import ei.algobaroapi.domain.room_member.dto.response.RoomMemberResponseDto;
 import java.util.List;
@@ -22,7 +22,7 @@ public interface RoomMemberService {
 
     RoomHostResponseDto changeHostManually(HostChangeRequestDto hostChangeRequestDto);
 
-    RoomHostDto changeHostAutomatically(HostAutoChangeRequestDto hostAutoChangeRequestDto);
+    RoomHostAutoChangeResponseDto changeHostAutomatically(HostAutoChangeRequestDto hostAutoChangeRequestDto);
 
     List<RoomMember> getByRoomIdAllReady(Long roomId);
 

--- a/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberServiceImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberServiceImpl.java
@@ -9,7 +9,7 @@ import ei.algobaroapi.domain.room_member.domain.RoomMember;
 import ei.algobaroapi.domain.room_member.domain.RoomMemberRepository;
 import ei.algobaroapi.domain.room_member.domain.RoomMemberRole;
 import ei.algobaroapi.domain.room_member.dto.request.HostAutoChangeRequestDto;
-import ei.algobaroapi.domain.room_member.dto.request.HostChangeRequestDto;
+import ei.algobaroapi.domain.room_member.dto.request.HostManualChangeRequestDto;
 import ei.algobaroapi.domain.room_member.dto.response.RoomHostAutoChangeResponseDto;
 import ei.algobaroapi.domain.room_member.dto.response.RoomHostResponseDto;
 import ei.algobaroapi.domain.room_member.dto.response.RoomMemberResponseDto;
@@ -95,12 +95,13 @@ public class RoomMemberServiceImpl implements RoomMemberService {
 
     @Override
     @Transactional
-    public RoomHostResponseDto changeHostManually(HostChangeRequestDto hostChangeRequestDto) {
-        RoomMember host = roomMemberRepository.findById(hostChangeRequestDto.getHostId())
+    public RoomHostResponseDto changeHostManually(
+            HostManualChangeRequestDto hostManualChangeRequestDto) {
+        RoomMember host = roomMemberRepository.findById(hostManualChangeRequestDto.getHostId())
                 .orElseThrow(() -> RoomMemberNotFoundException.of(
                         RoomMemberErrorCode.ROOM_MEMBER_ERROR_CODE));
 
-        RoomMember organizer = roomMemberRepository.findById(hostChangeRequestDto.getOrganizerId())
+        RoomMember organizer = roomMemberRepository.findById(hostManualChangeRequestDto.getOrganizerId())
                 .orElseThrow(() -> RoomMemberNotFoundException.of(
                         RoomMemberErrorCode.ROOM_MEMBER_ERROR_CODE));
 
@@ -110,7 +111,7 @@ public class RoomMemberServiceImpl implements RoomMemberService {
 
         organizer.changeRole(RoomMemberRole.HOST);
 
-        return RoomHostResponseDto.of(hostChangeRequestDto.getRoomId(), host, organizer);
+        return RoomHostResponseDto.of(hostManualChangeRequestDto.getRoomId(), host, organizer);
     }
 
     @Override

--- a/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberServiceImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberServiceImpl.java
@@ -107,9 +107,9 @@ public class RoomMemberServiceImpl implements RoomMemberService {
 
         validateIsHostAndOrganizer(host, organizer);
 
-        host.changeRole(RoomMemberRole.PARTICIPANT);
+        host.changeRoleToParticipant();
 
-        organizer.changeRole(RoomMemberRole.HOST);
+        organizer.changeRoleToHost();
 
         return RoomHostManualResponseDto.of(hostManualChangeRequestDto.getRoomId(), host, organizer);
     }
@@ -132,7 +132,7 @@ public class RoomMemberServiceImpl implements RoomMemberService {
                         RoomMemberErrorCode.ROOM_MEMBER_ERROR_CODE));
 
         // 방장으로 변경
-        newHost.changeRole(RoomMemberRole.HOST);
+        newHost.changeRoleToHost();
 
         return RoomHostAutoChangeResponseDto.of(roomId, newHost);
     }

--- a/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberServiceImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberServiceImpl.java
@@ -117,21 +117,14 @@ public class RoomMemberServiceImpl implements RoomMemberService {
     @Override
     @Transactional
     public RoomHostAutoChangeResponseDto changeHostAutomatically(HostAutoChangeRequestDto hostAutoChangeRequestDto) {
-        // 소켓을 통해 방장이 나갔음을 감지하고 해당 메서드 호출
-
         Long roomId = hostAutoChangeRequestDto.getRoomId();
 
-        // 해당 방에서 방장이 나갔으므로 해당 방장 정보 삭제
-        roomMemberRepository.deleteById(hostAutoChangeRequestDto.getHostId());
-
-        // 방장이 나갔을 때 방장이 아닌 사람 중 가장 먼저 들어온 사람을 탐색
         RoomMember newHost = roomMemberRepository.findByRoomId(roomId).stream()
                 .filter(RoomMember::isParticipant)
                 .min(Comparator.comparing(RoomMember::getCreatedAt))
                 .orElseThrow(() -> RoomMemberNotFoundException.of(
                         RoomMemberErrorCode.ROOM_MEMBER_ERROR_CODE));
 
-        // 방장으로 변경
         newHost.changeRoleToHost();
 
         return RoomHostAutoChangeResponseDto.of(roomId, newHost);

--- a/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberServiceImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberServiceImpl.java
@@ -82,6 +82,19 @@ public class RoomMemberServiceImpl implements RoomMemberService {
 
     @Override
     @Transactional
+    public RoomMemberResponseDto changeReadyStatus(Long roomId, Long memberId) {
+        RoomMember roomMember = roomMemberRepository.findRoomMemberByRoomIdAndMemberId(roomId,
+                        memberId)
+                .orElseThrow(() -> RoomMemberNotFoundException.of(
+                        RoomMemberErrorCode.ROOM_MEMBER_ERROR_CODE));
+
+        roomMember.changeReadyStatus();
+
+        return RoomMemberResponseDto.of(roomMember);
+    }
+
+    @Override
+    @Transactional
     public RoomHostResponseDto changeHostManually(HostChangeRequestDto hostChangeRequestDto) {
         RoomMember host = roomMemberRepository.findById(hostChangeRequestDto.getHostId())
                 .orElseThrow(() -> RoomMemberNotFoundException.of(
@@ -98,19 +111,6 @@ public class RoomMemberServiceImpl implements RoomMemberService {
         organizer.changeRole(RoomMemberRole.HOST);
 
         return RoomHostResponseDto.of(hostChangeRequestDto.getRoomId(), host, organizer);
-    }
-
-    @Override
-    @Transactional
-    public RoomMemberResponseDto changeReadyStatus(Long roomId, Long memberId) {
-        RoomMember roomMember = roomMemberRepository.findRoomMemberByRoomIdAndMemberId(roomId,
-                        memberId)
-                .orElseThrow(() -> RoomMemberNotFoundException.of(
-                        RoomMemberErrorCode.ROOM_MEMBER_ERROR_CODE));
-
-        roomMember.changeReadyStatus();
-
-        return RoomMemberResponseDto.of(roomMember);
     }
 
     @Override

--- a/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberServiceImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberServiceImpl.java
@@ -11,7 +11,7 @@ import ei.algobaroapi.domain.room_member.domain.RoomMemberRole;
 import ei.algobaroapi.domain.room_member.dto.request.HostAutoChangeRequestDto;
 import ei.algobaroapi.domain.room_member.dto.request.HostManualChangeRequestDto;
 import ei.algobaroapi.domain.room_member.dto.response.RoomHostAutoChangeResponseDto;
-import ei.algobaroapi.domain.room_member.dto.response.RoomHostResponseDto;
+import ei.algobaroapi.domain.room_member.dto.response.RoomHostManualResponseDto;
 import ei.algobaroapi.domain.room_member.dto.response.RoomMemberResponseDto;
 import ei.algobaroapi.domain.room_member.exception.HostValidationException;
 import ei.algobaroapi.domain.room_member.exception.OrganizerValidationException;
@@ -95,7 +95,7 @@ public class RoomMemberServiceImpl implements RoomMemberService {
 
     @Override
     @Transactional
-    public RoomHostResponseDto changeHostManually(
+    public RoomHostManualResponseDto changeHostManually(
             HostManualChangeRequestDto hostManualChangeRequestDto) {
         RoomMember host = roomMemberRepository.findById(hostManualChangeRequestDto.getHostId())
                 .orElseThrow(() -> RoomMemberNotFoundException.of(
@@ -111,7 +111,7 @@ public class RoomMemberServiceImpl implements RoomMemberService {
 
         organizer.changeRole(RoomMemberRole.HOST);
 
-        return RoomHostResponseDto.of(hostManualChangeRequestDto.getRoomId(), host, organizer);
+        return RoomHostManualResponseDto.of(hostManualChangeRequestDto.getRoomId(), host, organizer);
     }
 
     @Override

--- a/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberServiceImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberServiceImpl.java
@@ -10,7 +10,7 @@ import ei.algobaroapi.domain.room_member.domain.RoomMemberRepository;
 import ei.algobaroapi.domain.room_member.domain.RoomMemberRole;
 import ei.algobaroapi.domain.room_member.dto.request.HostAutoChangeRequestDto;
 import ei.algobaroapi.domain.room_member.dto.request.HostChangeRequestDto;
-import ei.algobaroapi.domain.room_member.dto.response.RoomHostDto;
+import ei.algobaroapi.domain.room_member.dto.response.RoomHostAutoChangeResponseDto;
 import ei.algobaroapi.domain.room_member.dto.response.RoomHostResponseDto;
 import ei.algobaroapi.domain.room_member.dto.response.RoomMemberResponseDto;
 import ei.algobaroapi.domain.room_member.exception.HostValidationException;
@@ -115,7 +115,7 @@ public class RoomMemberServiceImpl implements RoomMemberService {
 
     @Override
     @Transactional
-    public RoomHostDto changeHostAutomatically(HostAutoChangeRequestDto hostAutoChangeRequestDto) {
+    public RoomHostAutoChangeResponseDto changeHostAutomatically(HostAutoChangeRequestDto hostAutoChangeRequestDto) {
         // 소켓을 통해 방장이 나갔음을 감지하고 해당 메서드 호출
 
         Long roomId = hostAutoChangeRequestDto.getRoomId();
@@ -133,7 +133,7 @@ public class RoomMemberServiceImpl implements RoomMemberService {
         // 방장으로 변경
         newHost.changeRole(RoomMemberRole.HOST);
 
-        return RoomHostDto.of(roomId, newHost);
+        return RoomHostAutoChangeResponseDto.of(roomId, newHost);
     }
 
     @Override

--- a/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberServiceImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberServiceImpl.java
@@ -152,38 +152,30 @@ public class RoomMemberServiceImpl implements RoomMemberService {
     @Override
     @Transactional
     public List<RoomMemberResponseDto> exitRoomByMemberId(Long memberId) {
-        // 멤버가 있는 방 조회
         Room findRoom = roomMemberRepository.findRoomByMemberId(memberId)
                 .orElseThrow(() -> RoomNotFoundException.of(RoomErrorCode.ROOM_NOT_FOUND));
 
-        // 방 번호와 멤버 번호로 roomMember 조회
         RoomMember roomMember = roomMemberRepository.findRoomMemberByRoomIdAndMemberId(
                         findRoom.getId(), memberId)
                 .orElseThrow(() -> RoomMemberNotFoundException.of(
                         RoomMemberErrorCode.ROOM_MEMBER_ERROR_CODE));
 
-        // roomMember 삭제
         roomMemberRepository.delete(roomMember);
 
-        // 방에 남아있는 roomMember 조회 후 아무도 없다면 방 삭제
         if (checkRoomMemberExistInRoom(findRoom)) {
             roomRepository.delete(findRoom);
         }
 
-        // 방에 남아있는 roomMember 조회 <- 잘 삭제됐는지 확인용
         return roomMemberRepository.findByRoomId(findRoom.getId()).stream()
                 .map(RoomMemberResponseDto::of)
                 .toList();
     }
 
     private void validateConditionToJoinRoom(Room room, String password) {
-        // 방에 참여할 수 있는지 확인 - 모집 중인지 체크
         checkRoomIsRecruiting(room);
 
-        // 방에 참여할 수 있는지 확인 - 방 비밀번호 체크
         checkRoomPassword(room, password);
 
-        // 방에 참여할 수 있는지 확인 - 인원 수 체크
         checkRoomHeadCount(room);
     }
 

--- a/src/main/java/ei/algobaroapi/global/config/swaggerdoc/RoomMemberControllerDoc.java
+++ b/src/main/java/ei/algobaroapi/global/config/swaggerdoc/RoomMemberControllerDoc.java
@@ -4,7 +4,7 @@ import ei.algobaroapi.domain.member.domain.Member;
 import ei.algobaroapi.domain.room_member.dto.request.HostAutoChangeRequestDto;
 import ei.algobaroapi.domain.room_member.dto.request.HostChangeRequestDto;
 import ei.algobaroapi.domain.room_member.dto.request.JoinRoomRequestDto;
-import ei.algobaroapi.domain.room_member.dto.response.RoomHostDto;
+import ei.algobaroapi.domain.room_member.dto.response.RoomHostAutoChangeResponseDto;
 import ei.algobaroapi.domain.room_member.dto.response.RoomHostResponseDto;
 import ei.algobaroapi.domain.room_member.dto.response.RoomMemberResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
@@ -38,5 +38,5 @@ public interface RoomMemberControllerDoc {
 
     @Operation(summary = "방장 자동 변경", description = "현재 방장이 방을 나갔을 경우, 방에 참여한 순으로 방장을 새로 위임합니다.")
     @ApiResponse(responseCode = "200", description = "방장 자동 위임에 성공하였습니다.")
-    RoomHostDto changeHostAutomatically(HostAutoChangeRequestDto hostAutoChangeRequestDto);
+    RoomHostAutoChangeResponseDto changeHostAutomatically(HostAutoChangeRequestDto hostAutoChangeRequestDto);
 }

--- a/src/main/java/ei/algobaroapi/global/config/swaggerdoc/RoomMemberControllerDoc.java
+++ b/src/main/java/ei/algobaroapi/global/config/swaggerdoc/RoomMemberControllerDoc.java
@@ -5,7 +5,7 @@ import ei.algobaroapi.domain.room_member.dto.request.HostAutoChangeRequestDto;
 import ei.algobaroapi.domain.room_member.dto.request.HostManualChangeRequestDto;
 import ei.algobaroapi.domain.room_member.dto.request.JoinRoomRequestDto;
 import ei.algobaroapi.domain.room_member.dto.response.RoomHostAutoChangeResponseDto;
-import ei.algobaroapi.domain.room_member.dto.response.RoomHostResponseDto;
+import ei.algobaroapi.domain.room_member.dto.response.RoomHostManualResponseDto;
 import ei.algobaroapi.domain.room_member.dto.response.RoomMemberResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -34,7 +34,7 @@ public interface RoomMemberControllerDoc {
     @ApiResponse(responseCode = "E05301", description = "해당 방에 멤버를 찾지 못했습니다.")
     @ApiResponse(responseCode = "E05302", description = "방장 권한을 위임할 수 있는 권한을 가지고 있지 않습니다.")
     @ApiResponse(responseCode = "E05303", description = "방장 권한을 위임 받을 수 있는 참여자가 아닙니다.")
-    RoomHostResponseDto changeHostManually(HostManualChangeRequestDto hostManualChangeRequestDto);
+    RoomHostManualResponseDto changeHostManually(HostManualChangeRequestDto hostManualChangeRequestDto);
 
     @Operation(summary = "방장 자동 변경", description = "현재 방장이 방을 나갔을 경우, 방에 참여한 순으로 방장을 새로 위임합니다.")
     @ApiResponse(responseCode = "200", description = "방장 자동 위임에 성공하였습니다.")

--- a/src/main/java/ei/algobaroapi/global/config/swaggerdoc/RoomMemberControllerDoc.java
+++ b/src/main/java/ei/algobaroapi/global/config/swaggerdoc/RoomMemberControllerDoc.java
@@ -2,7 +2,7 @@ package ei.algobaroapi.global.config.swaggerdoc;
 
 import ei.algobaroapi.domain.member.domain.Member;
 import ei.algobaroapi.domain.room_member.dto.request.HostAutoChangeRequestDto;
-import ei.algobaroapi.domain.room_member.dto.request.HostChangeRequestDto;
+import ei.algobaroapi.domain.room_member.dto.request.HostManualChangeRequestDto;
 import ei.algobaroapi.domain.room_member.dto.request.JoinRoomRequestDto;
 import ei.algobaroapi.domain.room_member.dto.response.RoomHostAutoChangeResponseDto;
 import ei.algobaroapi.domain.room_member.dto.response.RoomHostResponseDto;
@@ -34,7 +34,7 @@ public interface RoomMemberControllerDoc {
     @ApiResponse(responseCode = "E05301", description = "해당 방에 멤버를 찾지 못했습니다.")
     @ApiResponse(responseCode = "E05302", description = "방장 권한을 위임할 수 있는 권한을 가지고 있지 않습니다.")
     @ApiResponse(responseCode = "E05303", description = "방장 권한을 위임 받을 수 있는 참여자가 아닙니다.")
-    RoomHostResponseDto changeHostManually(HostChangeRequestDto hostChangeRequestDto);
+    RoomHostResponseDto changeHostManually(HostManualChangeRequestDto hostManualChangeRequestDto);
 
     @Operation(summary = "방장 자동 변경", description = "현재 방장이 방을 나갔을 경우, 방에 참여한 순으로 방장을 새로 위임합니다.")
     @ApiResponse(responseCode = "200", description = "방장 자동 위임에 성공하였습니다.")

--- a/src/main/java/ei/algobaroapi/global/config/swaggerdoc/RoomMemberControllerDoc.java
+++ b/src/main/java/ei/algobaroapi/global/config/swaggerdoc/RoomMemberControllerDoc.java
@@ -1,9 +1,10 @@
 package ei.algobaroapi.global.config.swaggerdoc;
 
 import ei.algobaroapi.domain.member.domain.Member;
-import ei.algobaroapi.domain.room_member.domain.RoomMember;
+import ei.algobaroapi.domain.room_member.dto.request.HostAutoChangeRequestDto;
 import ei.algobaroapi.domain.room_member.dto.request.HostChangeRequestDto;
 import ei.algobaroapi.domain.room_member.dto.request.JoinRoomRequestDto;
+import ei.algobaroapi.domain.room_member.dto.response.RoomHostDto;
 import ei.algobaroapi.domain.room_member.dto.response.RoomHostResponseDto;
 import ei.algobaroapi.domain.room_member.dto.response.RoomMemberResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
@@ -35,7 +36,7 @@ public interface RoomMemberControllerDoc {
     @ApiResponse(responseCode = "E05303", description = "방장 권한을 위임 받을 수 있는 참여자가 아닙니다.")
     RoomHostResponseDto changeHostManually(HostChangeRequestDto hostChangeRequestDto);
 
-    @Operation(summary = "방장 자동 변경 - 작업 중", description = "현재 방장이 방을 나갔을 경우, 방에 참여한 순으로 방장을 새로 위임합니다.")
+    @Operation(summary = "방장 자동 변경", description = "현재 방장이 방을 나갔을 경우, 방에 참여한 순으로 방장을 새로 위임합니다.")
     @ApiResponse(responseCode = "200", description = "방장 자동 위임에 성공하였습니다.")
-    RoomHostResponseDto changeHostAutomatically(RoomMember roomMember);
+    RoomHostDto changeHostAutomatically(HostAutoChangeRequestDto hostAutoChangeRequestDto);
 }


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

방장 자동 변경 기능 구현
- 소켓으로 방장이 나갔음을 감지 후 메서드 호출(요청 정보 - roomId, exitHostId)
- 나간 방장의 정보 삭제
- 남은 참여자들의 방 참여 순서(RoomMember 엔티티 createdAt())를 고려하여 그 다음 사람에게 방장 위임

RoomMember chageRole 메서드 역할 분리

## 💬리뷰 시 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

작성한 주석처럼 로직을 생각하여 구현해보았습니다~ 
흐름따라 리뷰해주시면 감사하겠습니다!!
