### PR TITLE
문제 풀이 관련 API 소켓으로 전환 및 코드 전면 수정

### DIFF
--- a/src/main/java/ei/algobaroapi/domain/chat/controller/ChatMessageController.java
+++ b/src/main/java/ei/algobaroapi/domain/chat/controller/ChatMessageController.java
@@ -73,6 +73,18 @@ public class ChatMessageController {
         );
     }
 
+    @MessageMapping("/chat/change-host")
+    public void changeHostManually(
+            MessageRequest messageRequestDto,
+            @Header("Authorization") String authorization
+    ) {
+        chatService.changeHostManually(
+                messageRequestDto.getRoomId(),
+                tempParseMemberIdFromHeader(authorization),
+                Long.parseLong(messageRequestDto.getMessage())
+        );
+    }
+
     @MessageExceptionHandler
     public String exception() {
         return "Error has occurred.";

--- a/src/main/java/ei/algobaroapi/domain/chat/controller/ChatMessageController.java
+++ b/src/main/java/ei/algobaroapi/domain/chat/controller/ChatMessageController.java
@@ -51,6 +51,28 @@ public class ChatMessageController {
         );
     }
 
+    @MessageMapping("/chat/ready")
+    public void ready(
+            MessageRequest messageRequestDto,
+            @Header("Authorization") String authorization
+    ) {
+        chatService.readyRoom(
+                messageRequestDto.getRoomId(),
+                tempParseMemberIdFromHeader(authorization)
+        );
+    }
+
+    @MessageMapping("/chat/unready")
+    public void unready(
+            MessageRequest messageRequestDto,
+            @Header("Authorization") String authorization
+    ) {
+        chatService.unreadyRoom(
+                messageRequestDto.getRoomId(),
+                tempParseMemberIdFromHeader(authorization)
+        );
+    }
+
     @MessageExceptionHandler
     public String exception() {
         return "Error has occurred.";

--- a/src/main/java/ei/algobaroapi/domain/chat/controller/ChatMessageController.java
+++ b/src/main/java/ei/algobaroapi/domain/chat/controller/ChatMessageController.java
@@ -96,6 +96,17 @@ public class ChatMessageController {
         );
     }
 
+    @MessageMapping("/chat/end-coding")
+    public void endCodingTest(
+            MessageRequest messageRequestDto,
+            @Header("Authorization") String authorization
+    ) {
+        chatService.endCodingTest(
+                messageRequestDto.getRoomShortUuid(),
+                tempParseMemberIdFromHeader(authorization)
+        );
+    }
+
     @MessageExceptionHandler
     public String exception() {
         return "Error has occurred.";

--- a/src/main/java/ei/algobaroapi/domain/chat/controller/ChatMessageController.java
+++ b/src/main/java/ei/algobaroapi/domain/chat/controller/ChatMessageController.java
@@ -25,7 +25,7 @@ public class ChatMessageController {
             @Header("Authorization") String authorization
     ) {
         chatService.enterRoom(
-                messageRequestDto.getRoomId(),
+                messageRequestDto.getRoomShortUuid(),
                 tempParseMemberIdFromHeader(authorization)
         );
     }
@@ -35,7 +35,7 @@ public class ChatMessageController {
             MessageRequest messageRequestDto,
             @Header("Authorization") String authorization
     ) {
-        chatService.quitRoom(messageRequestDto.getRoomId(),
+        chatService.quitRoom(messageRequestDto.getRoomShortUuid(),
                 tempParseMemberIdFromHeader(authorization));
     }
 
@@ -45,7 +45,7 @@ public class ChatMessageController {
             @Header("Authorization") String authorization
     ) {
         chatService.convertAndSendMessage(
-                messageRequestDto.getRoomId(),
+                messageRequestDto.getRoomShortUuid(),
                 tempParseMemberIdFromHeader(authorization),
                 messageRequestDto.getMessage()
         );
@@ -57,7 +57,7 @@ public class ChatMessageController {
             @Header("Authorization") String authorization
     ) {
         chatService.readyRoom(
-                messageRequestDto.getRoomId(),
+                messageRequestDto.getRoomShortUuid(),
                 tempParseMemberIdFromHeader(authorization)
         );
     }
@@ -68,7 +68,7 @@ public class ChatMessageController {
             @Header("Authorization") String authorization
     ) {
         chatService.unreadyRoom(
-                messageRequestDto.getRoomId(),
+                messageRequestDto.getRoomShortUuid(),
                 tempParseMemberIdFromHeader(authorization)
         );
     }
@@ -79,7 +79,7 @@ public class ChatMessageController {
             @Header("Authorization") String authorization
     ) {
         chatService.changeHostManually(
-                messageRequestDto.getRoomId(),
+                messageRequestDto.getRoomShortUuid(),
                 tempParseMemberIdFromHeader(authorization),
                 Long.parseLong(messageRequestDto.getMessage())
         );

--- a/src/main/java/ei/algobaroapi/domain/chat/controller/ChatMessageController.java
+++ b/src/main/java/ei/algobaroapi/domain/chat/controller/ChatMessageController.java
@@ -1,7 +1,7 @@
 package ei.algobaroapi.domain.chat.controller;
 
 import ei.algobaroapi.domain.chat.dto.MessageRequest;
-import ei.algobaroapi.domain.chat.service.MessageService;
+import ei.algobaroapi.domain.chat.service.ChatService;
 import ei.algobaroapi.domain.member.domain.Member;
 import ei.algobaroapi.domain.member.service.MemberService;
 import ei.algobaroapi.global.jwt.JwtProvider;
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ChatMessageController {
 
     private static final String CHAT_ROOM_URL = "/chat/room/";
-    private final MessageService messageService;
+    private final ChatService chatService;
     private final SimpMessagingTemplate simpMessagingTemplate;
     private final JwtProvider jwtProvider;
     private final MemberService memberService;
@@ -28,7 +28,7 @@ public class ChatMessageController {
     public void enter(MessageRequest messageRequestDto) {
         simpMessagingTemplate.convertAndSend(
                 webSocketSubPrefix + CHAT_ROOM_URL + messageRequestDto.getRoomId(),
-                messageService.enterRoom(messageRequestDto.getUserId())
+                chatService.enterRoom(messageRequestDto.getUserId())
         );
     }
 
@@ -36,7 +36,7 @@ public class ChatMessageController {
     public void quit(MessageRequest messageRequestDto) {
         simpMessagingTemplate.convertAndSend(
                 webSocketSubPrefix + CHAT_ROOM_URL + messageRequestDto.getRoomId(),
-                messageService.quitRoom(messageRequestDto.getUserId())
+                chatService.quitRoom(messageRequestDto.getUserId())
         );
     }
 
@@ -44,7 +44,7 @@ public class ChatMessageController {
     public void message(MessageRequest messageRequestDto) {
         simpMessagingTemplate.convertAndSend(
                 webSocketSubPrefix + CHAT_ROOM_URL + messageRequestDto.getRoomId(),
-                messageService.convertAndSendMessage(
+                chatService.convertAndSendMessage(
                         messageRequestDto.getUserId(),
                         messageRequestDto.getMessage()
                 )

--- a/src/main/java/ei/algobaroapi/domain/chat/controller/ChatMessageController.java
+++ b/src/main/java/ei/algobaroapi/domain/chat/controller/ChatMessageController.java
@@ -2,6 +2,9 @@ package ei.algobaroapi.domain.chat.controller;
 
 import ei.algobaroapi.domain.chat.dto.MessageRequest;
 import ei.algobaroapi.domain.chat.service.MessageService;
+import ei.algobaroapi.domain.member.domain.Member;
+import ei.algobaroapi.domain.member.service.MemberService;
+import ei.algobaroapi.global.jwt.JwtProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
@@ -16,6 +19,8 @@ public class ChatMessageController {
     private static final String CHAT_ROOM_URL = "/chat/room/";
     private final MessageService messageService;
     private final SimpMessagingTemplate simpMessagingTemplate;
+    private final JwtProvider jwtProvider;
+    private final MemberService memberService;
     @Value("${spring.myapp.websocket.sub-prefix}")
     private String webSocketSubPrefix;
 
@@ -49,5 +54,12 @@ public class ChatMessageController {
     @MessageExceptionHandler
     public String exception() {
         return "Error has occurred.";
+    }
+
+    // 임시 사용, 추후 Custom Annotation으로 변경 예정
+    private Long tempParseMemberIdFromHeader(String authorization) {
+        String emailByToken = jwtProvider.getUserEmailByToken(authorization.substring(7));
+        Member memberByEmail = memberService.getMemberByEmail(emailByToken);
+        return memberByEmail.getId();
     }
 }

--- a/src/main/java/ei/algobaroapi/domain/chat/controller/ChatMessageController.java
+++ b/src/main/java/ei/algobaroapi/domain/chat/controller/ChatMessageController.java
@@ -20,18 +20,30 @@ public class ChatMessageController {
     private final MemberService memberService;
 
     @MessageMapping("/chat/enter")
-    public void enter(MessageRequest messageRequestDto, @Header("Authorization") String authorization) {
-        Long memberId = tempParseMemberIdFromHeader(authorization);
-        chatService.enterRoom(messageRequestDto.getRoomId(), memberId);
+    public void enter(
+            MessageRequest messageRequestDto,
+            @Header("Authorization") String authorization
+    ) {
+        chatService.enterRoom(
+                messageRequestDto.getRoomId(),
+                tempParseMemberIdFromHeader(authorization)
+        );
     }
 
     @MessageMapping("/chat/quit")
-    public void quit(MessageRequest messageRequestDto, @Header("Authorization") String authorization) {
-        chatService.quitRoom(messageRequestDto.getRoomId(), tempParseMemberIdFromHeader(authorization));
+    public void quit(
+            MessageRequest messageRequestDto,
+            @Header("Authorization") String authorization
+    ) {
+        chatService.quitRoom(messageRequestDto.getRoomId(),
+                tempParseMemberIdFromHeader(authorization));
     }
 
     @MessageMapping("/chat/message")
-    public void message(MessageRequest messageRequestDto, @Header("Authorization") String authorization) {
+    public void message(
+            MessageRequest messageRequestDto,
+            @Header("Authorization") String authorization
+    ) {
         chatService.convertAndSendMessage(
                 messageRequestDto.getRoomId(),
                 tempParseMemberIdFromHeader(authorization),

--- a/src/main/java/ei/algobaroapi/domain/chat/controller/ChatMessageController.java
+++ b/src/main/java/ei/algobaroapi/domain/chat/controller/ChatMessageController.java
@@ -85,6 +85,17 @@ public class ChatMessageController {
         );
     }
 
+    @MessageMapping("/chat/start-coding")
+    public void startCodingTest(
+            MessageRequest messageRequestDto,
+            @Header("Authorization") String authorization
+    ) {
+        chatService.startCodingTest(
+                messageRequestDto.getRoomShortUuid(),
+                tempParseMemberIdFromHeader(authorization)
+        );
+    }
+
     @MessageExceptionHandler
     public String exception() {
         return "Error has occurred.";

--- a/src/main/java/ei/algobaroapi/domain/chat/dto/MessageRequest.java
+++ b/src/main/java/ei/algobaroapi/domain/chat/dto/MessageRequest.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 @Builder
 public class MessageRequest {
 
-    private String roomId;
+    private String roomShortUuid;
 
     private Long memberId;
 

--- a/src/main/java/ei/algobaroapi/domain/chat/dto/MessageRequest.java
+++ b/src/main/java/ei/algobaroapi/domain/chat/dto/MessageRequest.java
@@ -9,7 +9,7 @@ public class MessageRequest {
 
     private String roomId;
 
-    private String userId;
+    private Long memberId;
 
     private String message;
 }

--- a/src/main/java/ei/algobaroapi/domain/chat/dto/MessageRequest.java
+++ b/src/main/java/ei/algobaroapi/domain/chat/dto/MessageRequest.java
@@ -9,7 +9,5 @@ public class MessageRequest {
 
     private String roomShortUuid;
 
-    private Long memberId;
-
     private String message;
 }

--- a/src/main/java/ei/algobaroapi/domain/chat/dto/MessageResponse.java
+++ b/src/main/java/ei/algobaroapi/domain/chat/dto/MessageResponse.java
@@ -40,4 +40,20 @@ public class MessageResponse {
                 value
         );
     }
+
+    public static MessageResponse readyRoom(Long memberId) {
+        return new MessageResponse(
+                memberId,
+                MessageType.READY_ROOM,
+                null
+        );
+    }
+
+    public static MessageResponse unreadyRoom(Long memberId) {
+        return new MessageResponse(
+                memberId,
+                MessageType.UNREADY_ROOM,
+                null
+        );
+    }
 }

--- a/src/main/java/ei/algobaroapi/domain/chat/dto/MessageResponse.java
+++ b/src/main/java/ei/algobaroapi/domain/chat/dto/MessageResponse.java
@@ -9,33 +9,33 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class MessageResponse {
 
-    private final String userId;
+    private final Long memberId;
     private final MessageType type;
     private final String value;
     private final String timestamp = LocalDateTime.now().toString();
 
-    public static MessageResponse enterRoom(String userId) {
+    public static MessageResponse enterRoom(Long memberId) {
         return new MessageResponse(
-                userId,
+                memberId,
                 MessageType.ENTER_ROOM,
                 null
         );
     }
 
-    public static MessageResponse quitRoom(String userId) {
+    public static MessageResponse quitRoom(Long memberId) {
         return new MessageResponse(
-                userId,
+                memberId,
                 MessageType.QUIT_ROOM,
                 null
         );
     }
 
     public static MessageResponse sendMessage(
-            String userId,
+            Long memberId,
             String value
     ) {
         return new MessageResponse(
-                userId,
+                memberId,
                 MessageType.SEND_MESSAGE,
                 value
         );

--- a/src/main/java/ei/algobaroapi/domain/chat/dto/MessageResponse.java
+++ b/src/main/java/ei/algobaroapi/domain/chat/dto/MessageResponse.java
@@ -72,4 +72,12 @@ public class MessageResponse {
                 null
         );
     }
+
+    public static MessageResponse endCoding(Long memberId) {
+        return new MessageResponse(
+                memberId,
+                MessageType.END_CODING,
+                null
+        );
+    }
 }

--- a/src/main/java/ei/algobaroapi/domain/chat/dto/MessageResponse.java
+++ b/src/main/java/ei/algobaroapi/domain/chat/dto/MessageResponse.java
@@ -56,4 +56,12 @@ public class MessageResponse {
                 null
         );
     }
+
+    public static MessageResponse changeHost(Long memberId) {
+        return new MessageResponse(
+                memberId,
+                MessageType.CHANGE_HOST,
+                null
+        );
+    }
 }

--- a/src/main/java/ei/algobaroapi/domain/chat/dto/MessageResponse.java
+++ b/src/main/java/ei/algobaroapi/domain/chat/dto/MessageResponse.java
@@ -64,4 +64,12 @@ public class MessageResponse {
                 null
         );
     }
+
+    public static MessageResponse startCoding(Long memberId) {
+        return new MessageResponse(
+                memberId,
+                MessageType.START_CODING,
+                null
+        );
+    }
 }

--- a/src/main/java/ei/algobaroapi/domain/chat/dto/MessageType.java
+++ b/src/main/java/ei/algobaroapi/domain/chat/dto/MessageType.java
@@ -9,7 +9,9 @@ import lombok.RequiredArgsConstructor;
 public enum MessageType {
     ENTER_ROOM("enter"),
     QUIT_ROOM("quit"),
-    SEND_MESSAGE("message");
+    SEND_MESSAGE("message"),
+    READY_ROOM("ready"),
+    UNREADY_ROOM("unready");
 
     @JsonValue
     private final String value;

--- a/src/main/java/ei/algobaroapi/domain/chat/dto/MessageType.java
+++ b/src/main/java/ei/algobaroapi/domain/chat/dto/MessageType.java
@@ -11,7 +11,8 @@ public enum MessageType {
     QUIT_ROOM("quit"),
     SEND_MESSAGE("message"),
     READY_ROOM("ready"),
-    UNREADY_ROOM("unready");
+    UNREADY_ROOM("unready"),
+    CHANGE_HOST("changeHost");
 
     @JsonValue
     private final String value;

--- a/src/main/java/ei/algobaroapi/domain/chat/dto/MessageType.java
+++ b/src/main/java/ei/algobaroapi/domain/chat/dto/MessageType.java
@@ -13,7 +13,8 @@ public enum MessageType {
     READY_ROOM("ready"),
     UNREADY_ROOM("unready"),
     CHANGE_HOST("change-host"),
-    START_CODING("start-coding");
+    START_CODING("start-coding"),
+    END_CODING("end-coding");
 
     @JsonValue
     private final String value;

--- a/src/main/java/ei/algobaroapi/domain/chat/dto/MessageType.java
+++ b/src/main/java/ei/algobaroapi/domain/chat/dto/MessageType.java
@@ -12,7 +12,8 @@ public enum MessageType {
     SEND_MESSAGE("message"),
     READY_ROOM("ready"),
     UNREADY_ROOM("unready"),
-    CHANGE_HOST("changeHost");
+    CHANGE_HOST("change-host"),
+    START_CODING("start-coding");
 
     @JsonValue
     private final String value;

--- a/src/main/java/ei/algobaroapi/domain/chat/service/ChatService.java
+++ b/src/main/java/ei/algobaroapi/domain/chat/service/ChatService.java
@@ -2,15 +2,15 @@ package ei.algobaroapi.domain.chat.service;
 
 public interface ChatService {
 
-    void enterRoom(String roomId, Long memberId);
+    void enterRoom(String roomShortUuid, Long memberId);
 
-    void quitRoom(String roomId, Long memberId);
+    void quitRoom(String roomShortUuid, Long memberId);
 
-    void convertAndSendMessage(String roomId, Long memberId, String message);
+    void convertAndSendMessage(String roomShortUuid, Long memberId, String message);
 
-    void readyRoom(String roomId, Long memberId);
+    void readyRoom(String roomShortUuid, Long memberId);
 
-    void unreadyRoom(String roomId, Long memberId);
+    void unreadyRoom(String roomShortUuid, Long memberId);
 
-    void changeHostManually(String roomId, Long beforeHost, Long afterHost);
+    void changeHostManually(String roomShortUuid, Long beforeHost, Long afterHost);
 }

--- a/src/main/java/ei/algobaroapi/domain/chat/service/ChatService.java
+++ b/src/main/java/ei/algobaroapi/domain/chat/service/ChatService.java
@@ -13,4 +13,6 @@ public interface ChatService {
     void unreadyRoom(String roomShortUuid, Long memberId);
 
     void changeHostManually(String roomShortUuid, Long beforeHost, Long afterHost);
+
+    void startCodingTest(String roomShortUuid, Long memberId);
 }

--- a/src/main/java/ei/algobaroapi/domain/chat/service/ChatService.java
+++ b/src/main/java/ei/algobaroapi/domain/chat/service/ChatService.java
@@ -2,7 +2,7 @@ package ei.algobaroapi.domain.chat.service;
 
 import ei.algobaroapi.domain.chat.dto.MessageResponse;
 
-public interface MessageService {
+public interface ChatService {
 
     MessageResponse enterRoom(String userId);
 

--- a/src/main/java/ei/algobaroapi/domain/chat/service/ChatService.java
+++ b/src/main/java/ei/algobaroapi/domain/chat/service/ChatService.java
@@ -7,4 +7,8 @@ public interface ChatService {
     void quitRoom(String roomId, Long memberId);
 
     void convertAndSendMessage(String roomId, Long memberId, String message);
+
+    void readyRoom(String roomId, Long memberId);
+
+    void unreadyRoom(String roomId, Long aLong);
 }

--- a/src/main/java/ei/algobaroapi/domain/chat/service/ChatService.java
+++ b/src/main/java/ei/algobaroapi/domain/chat/service/ChatService.java
@@ -15,4 +15,6 @@ public interface ChatService {
     void changeHostManually(String roomShortUuid, Long beforeHost, Long afterHost);
 
     void startCodingTest(String roomShortUuid, Long memberId);
+
+    void endCodingTest(String roomShortUuid, Long memberId);
 }

--- a/src/main/java/ei/algobaroapi/domain/chat/service/ChatService.java
+++ b/src/main/java/ei/algobaroapi/domain/chat/service/ChatService.java
@@ -10,5 +10,7 @@ public interface ChatService {
 
     void readyRoom(String roomId, Long memberId);
 
-    void unreadyRoom(String roomId, Long aLong);
+    void unreadyRoom(String roomId, Long memberId);
+
+    void changeHostManually(String roomId, Long beforeHost, Long afterHost);
 }

--- a/src/main/java/ei/algobaroapi/domain/chat/service/ChatService.java
+++ b/src/main/java/ei/algobaroapi/domain/chat/service/ChatService.java
@@ -12,7 +12,7 @@ public interface ChatService {
 
     void unreadyRoom(String roomShortUuid, Long memberId);
 
-    void changeHostManually(String roomShortUuid, Long beforeHost, Long afterHost);
+    void changeHostManually(String roomShortUuid, Long beforeHostMemberId, Long afterHostMemberId);
 
     void startCodingTest(String roomShortUuid, Long memberId);
 

--- a/src/main/java/ei/algobaroapi/domain/chat/service/ChatService.java
+++ b/src/main/java/ei/algobaroapi/domain/chat/service/ChatService.java
@@ -1,12 +1,10 @@
 package ei.algobaroapi.domain.chat.service;
 
-import ei.algobaroapi.domain.chat.dto.MessageResponse;
-
 public interface ChatService {
 
-    MessageResponse enterRoom(String userId);
+    void enterRoom(String roomId, Long memberId);
 
-    MessageResponse quitRoom(String userId);
+    void quitRoom(String roomId, Long memberId);
 
-    MessageResponse convertAndSendMessage(String userId, String message);
+    void convertAndSendMessage(String roomId, Long memberId, String message);
 }

--- a/src/main/java/ei/algobaroapi/domain/chat/service/ChatServiceImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/chat/service/ChatServiceImpl.java
@@ -3,6 +3,7 @@ package ei.algobaroapi.domain.chat.service;
 import ei.algobaroapi.domain.chat.dto.MessageResponse;
 import ei.algobaroapi.domain.member.domain.Member;
 import ei.algobaroapi.domain.member.service.MemberService;
+import ei.algobaroapi.domain.room_member.dto.request.HostManualChangeRequestDto;
 import ei.algobaroapi.domain.room_member.service.RoomMemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -43,5 +44,16 @@ public class ChatServiceImpl implements ChatService {
     public void unreadyRoom(String roomId, Long memberId) {
         roomMemberService.chageStatusToUnready(roomId, memberId);
         messageService.sendMessage(roomId, MessageResponse.unreadyRoom(memberId));
+    }
+
+    @Override
+    public void changeHostManually(String roomId, Long beforeHostId, Long afterHostId) {
+        roomMemberService.changeHostManually(HostManualChangeRequestDto.builder()
+                .roomShortUuid(roomId)
+                .hostId(beforeHostId)
+                .organizerId(afterHostId)
+                .build()
+        );
+        messageService.sendMessage(roomId, MessageResponse.changeHost(beforeHostId));
     }
 }

--- a/src/main/java/ei/algobaroapi/domain/chat/service/ChatServiceImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/chat/service/ChatServiceImpl.java
@@ -1,6 +1,7 @@
 package ei.algobaroapi.domain.chat.service;
 
 import ei.algobaroapi.domain.chat.dto.MessageResponse;
+import ei.algobaroapi.domain.room_member.service.RoomMemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -9,6 +10,7 @@ import org.springframework.stereotype.Service;
 public class ChatServiceImpl implements ChatService {
 
     private final MessageService messageService;
+    private final RoomMemberService roomMemberService;
 
     @Override
     public void enterRoom(String roomId, Long memberId) {
@@ -17,6 +19,7 @@ public class ChatServiceImpl implements ChatService {
 
     @Override
     public void quitRoom(String roomId, Long memberId) {
+        roomMemberService.exitRoomByMemberId(memberId);
         messageService.sendMessage(roomId, MessageResponse.quitRoom(memberId));
     }
 

--- a/src/main/java/ei/algobaroapi/domain/chat/service/ChatServiceImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/chat/service/ChatServiceImpl.java
@@ -8,18 +8,20 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class ChatServiceImpl implements ChatService {
 
+    private final MessageService messageService;
+
     @Override
-    public MessageResponse enterRoom(String userId) {
-        return MessageResponse.enterRoom(userId);
+    public void enterRoom(String roomId, Long memberId) {
+        messageService.sendMessage(roomId, MessageResponse.enterRoom(memberId));
     }
 
     @Override
-    public MessageResponse quitRoom(String userId) {
-        return MessageResponse.quitRoom(userId);
+    public void quitRoom(String roomId, Long memberId) {
+        messageService.sendMessage(roomId, MessageResponse.quitRoom(memberId));
     }
 
     @Override
-    public MessageResponse convertAndSendMessage(String userId, String message) {
-        return MessageResponse.sendMessage(userId, message);
+    public void convertAndSendMessage(String roomId, Long memberId, String message) {
+        messageService.sendMessage(roomId, MessageResponse.sendMessage(memberId, message));
     }
 }

--- a/src/main/java/ei/algobaroapi/domain/chat/service/ChatServiceImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/chat/service/ChatServiceImpl.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-public class MessageServiceImpl implements MessageService {
+public class ChatServiceImpl implements ChatService {
 
     @Override
     public MessageResponse enterRoom(String userId) {

--- a/src/main/java/ei/algobaroapi/domain/chat/service/ChatServiceImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/chat/service/ChatServiceImpl.java
@@ -54,14 +54,18 @@ public class ChatServiceImpl implements ChatService {
     }
 
     @Override
-    public void changeHostManually(String roomShortUuid, Long beforeHostId, Long afterHostId) {
+    public void changeHostManually(
+            String roomShortUuid,
+            Long beforeHostMemberId,
+            Long afterHostMemberId
+    ) {
         roomMemberService.changeHostManually(HostManualChangeRequestDto.builder()
                 .roomShortUuid(roomShortUuid)
-                .hostId(beforeHostId)
-                .organizerId(afterHostId)
+                .hostMemberId(beforeHostMemberId)
+                .organizerMemberId(afterHostMemberId)
                 .build()
         );
-        messageService.sendMessage(roomShortUuid, MessageResponse.changeHost(afterHostId));
+        messageService.sendMessage(roomShortUuid, MessageResponse.changeHost(afterHostMemberId));
     }
 
     @Override

--- a/src/main/java/ei/algobaroapi/domain/chat/service/ChatServiceImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/chat/service/ChatServiceImpl.java
@@ -1,6 +1,8 @@
 package ei.algobaroapi.domain.chat.service;
 
 import ei.algobaroapi.domain.chat.dto.MessageResponse;
+import ei.algobaroapi.domain.member.domain.Member;
+import ei.algobaroapi.domain.member.service.MemberService;
 import ei.algobaroapi.domain.room_member.service.RoomMemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -10,10 +12,13 @@ import org.springframework.stereotype.Service;
 public class ChatServiceImpl implements ChatService {
 
     private final MessageService messageService;
+    private final MemberService memberService;
     private final RoomMemberService roomMemberService;
 
     @Override
     public void enterRoom(String roomId, Long memberId) {
+        Member member = memberService.getMemberById(memberId);
+        roomMemberService.joinRoomByRoomShortUuid(roomId, member);
         messageService.sendMessage(roomId, MessageResponse.enterRoom(memberId));
     }
 

--- a/src/main/java/ei/algobaroapi/domain/chat/service/ChatServiceImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/chat/service/ChatServiceImpl.java
@@ -3,6 +3,7 @@ package ei.algobaroapi.domain.chat.service;
 import ei.algobaroapi.domain.chat.dto.MessageResponse;
 import ei.algobaroapi.domain.member.domain.Member;
 import ei.algobaroapi.domain.member.service.MemberService;
+import ei.algobaroapi.domain.room.service.RoomService;
 import ei.algobaroapi.domain.room_member.dto.request.HostManualChangeRequestDto;
 import ei.algobaroapi.domain.room_member.dto.response.RoomExitResponse;
 import ei.algobaroapi.domain.room_member.service.RoomMemberService;
@@ -15,6 +16,7 @@ public class ChatServiceImpl implements ChatService {
 
     private final MessageService messageService;
     private final MemberService memberService;
+    private final RoomService roomService;
     private final RoomMemberService roomMemberService;
 
     @Override
@@ -59,5 +61,11 @@ public class ChatServiceImpl implements ChatService {
                 .build()
         );
         messageService.sendMessage(roomShortUuid, MessageResponse.changeHost(beforeHostId));
+    }
+
+    @Override
+    public void startCodingTest(String roomShortUuid, Long memberId) {
+        roomService.startCodingTest(roomShortUuid);
+        messageService.sendMessage(roomShortUuid, MessageResponse.startCoding(memberId));
     }
 }

--- a/src/main/java/ei/algobaroapi/domain/chat/service/ChatServiceImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/chat/service/ChatServiceImpl.java
@@ -4,6 +4,7 @@ import ei.algobaroapi.domain.chat.dto.MessageResponse;
 import ei.algobaroapi.domain.member.domain.Member;
 import ei.algobaroapi.domain.member.service.MemberService;
 import ei.algobaroapi.domain.room_member.dto.request.HostManualChangeRequestDto;
+import ei.algobaroapi.domain.room_member.dto.response.RoomExitResponse;
 import ei.algobaroapi.domain.room_member.service.RoomMemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -25,7 +26,10 @@ public class ChatServiceImpl implements ChatService {
 
     @Override
     public void quitRoom(String roomShortUuid, Long memberId) {
-        roomMemberService.exitRoomByMemberId(memberId);
+        RoomExitResponse roomExitResponse = roomMemberService.exitRoomByMemberId(memberId);
+        if (roomExitResponse.isHostChanged()) {
+            messageService.sendMessage(roomShortUuid, MessageResponse.changeHost(roomExitResponse.getNewHostId()));
+        }
         messageService.sendMessage(roomShortUuid, MessageResponse.quitRoom(memberId));
     }
 

--- a/src/main/java/ei/algobaroapi/domain/chat/service/ChatServiceImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/chat/service/ChatServiceImpl.java
@@ -17,43 +17,43 @@ public class ChatServiceImpl implements ChatService {
     private final RoomMemberService roomMemberService;
 
     @Override
-    public void enterRoom(String roomId, Long memberId) {
+    public void enterRoom(String roomShortUuid, Long memberId) {
         Member member = memberService.getMemberById(memberId);
-        roomMemberService.joinRoomByRoomShortUuid(roomId, member);
-        messageService.sendMessage(roomId, MessageResponse.enterRoom(memberId));
+        roomMemberService.joinRoomByRoomShortUuid(roomShortUuid, member);
+        messageService.sendMessage(roomShortUuid, MessageResponse.enterRoom(memberId));
     }
 
     @Override
-    public void quitRoom(String roomId, Long memberId) {
+    public void quitRoom(String roomShortUuid, Long memberId) {
         roomMemberService.exitRoomByMemberId(memberId);
-        messageService.sendMessage(roomId, MessageResponse.quitRoom(memberId));
+        messageService.sendMessage(roomShortUuid, MessageResponse.quitRoom(memberId));
     }
 
     @Override
-    public void convertAndSendMessage(String roomId, Long memberId, String message) {
-        messageService.sendMessage(roomId, MessageResponse.sendMessage(memberId, message));
+    public void convertAndSendMessage(String roomShortUuid, Long memberId, String message) {
+        messageService.sendMessage(roomShortUuid, MessageResponse.sendMessage(memberId, message));
     }
 
     @Override
-    public void readyRoom(String roomId, Long memberId) {
-        roomMemberService.chageStatusToReady(roomId, memberId);
-        messageService.sendMessage(roomId, MessageResponse.readyRoom(memberId));
+    public void readyRoom(String roomShortUuid, Long memberId) {
+        roomMemberService.chageStatusToReady(roomShortUuid, memberId);
+        messageService.sendMessage(roomShortUuid, MessageResponse.readyRoom(memberId));
     }
 
     @Override
-    public void unreadyRoom(String roomId, Long memberId) {
-        roomMemberService.chageStatusToUnready(roomId, memberId);
-        messageService.sendMessage(roomId, MessageResponse.unreadyRoom(memberId));
+    public void unreadyRoom(String roomShortUuid, Long memberId) {
+        roomMemberService.chageStatusToUnready(roomShortUuid, memberId);
+        messageService.sendMessage(roomShortUuid, MessageResponse.unreadyRoom(memberId));
     }
 
     @Override
-    public void changeHostManually(String roomId, Long beforeHostId, Long afterHostId) {
+    public void changeHostManually(String roomShortUuid, Long beforeHostId, Long afterHostId) {
         roomMemberService.changeHostManually(HostManualChangeRequestDto.builder()
-                .roomShortUuid(roomId)
+                .roomShortUuid(roomShortUuid)
                 .hostId(beforeHostId)
                 .organizerId(afterHostId)
                 .build()
         );
-        messageService.sendMessage(roomId, MessageResponse.changeHost(beforeHostId));
+        messageService.sendMessage(roomShortUuid, MessageResponse.changeHost(beforeHostId));
     }
 }

--- a/src/main/java/ei/algobaroapi/domain/chat/service/ChatServiceImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/chat/service/ChatServiceImpl.java
@@ -61,7 +61,7 @@ public class ChatServiceImpl implements ChatService {
                 .organizerId(afterHostId)
                 .build()
         );
-        messageService.sendMessage(roomShortUuid, MessageResponse.changeHost(beforeHostId));
+        messageService.sendMessage(roomShortUuid, MessageResponse.changeHost(afterHostId));
     }
 
     @Override

--- a/src/main/java/ei/algobaroapi/domain/chat/service/ChatServiceImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/chat/service/ChatServiceImpl.java
@@ -32,4 +32,16 @@ public class ChatServiceImpl implements ChatService {
     public void convertAndSendMessage(String roomId, Long memberId, String message) {
         messageService.sendMessage(roomId, MessageResponse.sendMessage(memberId, message));
     }
+
+    @Override
+    public void readyRoom(String roomId, Long memberId) {
+        roomMemberService.chageStatusToReady(roomId, memberId);
+        messageService.sendMessage(roomId, MessageResponse.readyRoom(memberId));
+    }
+
+    @Override
+    public void unreadyRoom(String roomId, Long memberId) {
+        roomMemberService.chageStatusToUnready(roomId, memberId);
+        messageService.sendMessage(roomId, MessageResponse.unreadyRoom(memberId));
+    }
 }

--- a/src/main/java/ei/algobaroapi/domain/chat/service/ChatServiceImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/chat/service/ChatServiceImpl.java
@@ -7,6 +7,8 @@ import ei.algobaroapi.domain.room.service.RoomService;
 import ei.algobaroapi.domain.room_member.dto.request.HostManualChangeRequestDto;
 import ei.algobaroapi.domain.room_member.dto.response.RoomExitResponse;
 import ei.algobaroapi.domain.room_member.service.RoomMemberService;
+import ei.algobaroapi.domain.solve.service.SolveHistoryService;
+import ei.algobaroapi.domain.solve.service.SolveService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -18,6 +20,7 @@ public class ChatServiceImpl implements ChatService {
     private final MemberService memberService;
     private final RoomService roomService;
     private final RoomMemberService roomMemberService;
+    private final SolveHistoryService solveHistoryService;
 
     @Override
     public void enterRoom(String roomShortUuid, Long memberId) {
@@ -67,5 +70,11 @@ public class ChatServiceImpl implements ChatService {
     public void startCodingTest(String roomShortUuid, Long memberId) {
         roomService.startCodingTest(roomShortUuid);
         messageService.sendMessage(roomShortUuid, MessageResponse.startCoding(memberId));
+    }
+
+    @Override
+    public void endCodingTest(String roomShortUuid, Long memberId) {
+        solveHistoryService.completeSolveHistory(roomShortUuid);
+        messageService.sendMessage(roomShortUuid, MessageResponse.endCoding(memberId));
     }
 }

--- a/src/main/java/ei/algobaroapi/domain/chat/service/ChatServiceImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/chat/service/ChatServiceImpl.java
@@ -7,8 +7,6 @@ import ei.algobaroapi.domain.room.service.RoomService;
 import ei.algobaroapi.domain.room_member.dto.request.HostManualChangeRequestDto;
 import ei.algobaroapi.domain.room_member.dto.response.RoomExitResponse;
 import ei.algobaroapi.domain.room_member.service.RoomMemberService;
-import ei.algobaroapi.domain.solve.service.SolveHistoryService;
-import ei.algobaroapi.domain.solve.service.SolveService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -20,7 +18,6 @@ public class ChatServiceImpl implements ChatService {
     private final MemberService memberService;
     private final RoomService roomService;
     private final RoomMemberService roomMemberService;
-    private final SolveHistoryService solveHistoryService;
 
     @Override
     public void enterRoom(String roomShortUuid, Long memberId) {
@@ -33,7 +30,8 @@ public class ChatServiceImpl implements ChatService {
     public void quitRoom(String roomShortUuid, Long memberId) {
         RoomExitResponse roomExitResponse = roomMemberService.exitRoomByMemberId(memberId);
         if (roomExitResponse.isHostChanged()) {
-            messageService.sendMessage(roomShortUuid, MessageResponse.changeHost(roomExitResponse.getNewHostId()));
+            messageService.sendMessage(roomShortUuid,
+                    MessageResponse.changeHost(roomExitResponse.getNewHostId()));
         }
         messageService.sendMessage(roomShortUuid, MessageResponse.quitRoom(memberId));
     }
@@ -74,7 +72,7 @@ public class ChatServiceImpl implements ChatService {
 
     @Override
     public void endCodingTest(String roomShortUuid, Long memberId) {
-        solveHistoryService.completeSolveHistory(roomShortUuid);
+        roomService.completeSolveHistory(roomShortUuid);
         messageService.sendMessage(roomShortUuid, MessageResponse.endCoding(memberId));
     }
 }

--- a/src/main/java/ei/algobaroapi/domain/chat/service/MessageService.java
+++ b/src/main/java/ei/algobaroapi/domain/chat/service/MessageService.java
@@ -1,0 +1,24 @@
+package ei.algobaroapi.domain.chat.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MessageService {
+
+    private static final String CHAT_ROOM_URL = "/chat/room/";
+    private final SimpMessagingTemplate simpMessagingTemplate;
+    @Value("${spring.myapp.websocket.sub-prefix}")
+    private String webSocketSubPrefix;
+
+
+    public void sendMessage(String roomId, Object payload) {
+        simpMessagingTemplate.convertAndSend(
+                webSocketSubPrefix + CHAT_ROOM_URL + roomId,
+                payload
+        );
+    }
+}

--- a/src/main/java/ei/algobaroapi/domain/room/controller/RoomControllerDocImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/room/controller/RoomControllerDocImpl.java
@@ -57,7 +57,7 @@ public class RoomControllerDocImpl implements RoomControllerDoc {
     @GetMapping("/rooms/{roomShortUuid}")
     public RoomDetailResponseDto getRoomByShortUuid(
             @PathVariable(name = "roomShortUuid") String roomShortUuid) {
-        return roomService.getRoomByRoomUuid(roomShortUuid);
+        return roomService.getRoomDetailShortUuid(roomShortUuid);
     }
 
     @Override

--- a/src/main/java/ei/algobaroapi/domain/room/domain/Room.java
+++ b/src/main/java/ei/algobaroapi/domain/room/domain/Room.java
@@ -138,6 +138,10 @@ public class Room extends BaseEntity {
         return this.roomStatus == RoomStatus.RECRUITING;
     }
 
+    public boolean isRunning() {
+        return this.roomStatus == RoomStatus.RUNNING;
+    }
+
     public boolean passwordIsCorrect(String password) {
         return this.password.equals(password);
     }

--- a/src/main/java/ei/algobaroapi/domain/room/service/RoomService.java
+++ b/src/main/java/ei/algobaroapi/domain/room/service/RoomService.java
@@ -18,7 +18,9 @@ public interface RoomService {
     RoomResponseDto updateRoomByRoomId(Long roomId,
             RoomUpdateRequestDto roomUpdateRequestDto);
 
-    RoomDetailResponseDto getRoomByRoomUuid(String roomUuid);
+    RoomDetailResponseDto getRoomDetailShortUuid(String roomUuid);
+
+    Room getRoomByShortUuid(String roomUuid);
 
     RoomDetailResponseDto startCodingTest(String roomUuid);
 }

--- a/src/main/java/ei/algobaroapi/domain/room/service/RoomService.java
+++ b/src/main/java/ei/algobaroapi/domain/room/service/RoomService.java
@@ -20,7 +20,5 @@ public interface RoomService {
 
     RoomDetailResponseDto getRoomDetailShortUuid(String roomUuid);
 
-    Room getRoomByShortUuid(String roomUuid);
-
     RoomDetailResponseDto startCodingTest(String roomUuid);
 }

--- a/src/main/java/ei/algobaroapi/domain/room/service/RoomService.java
+++ b/src/main/java/ei/algobaroapi/domain/room/service/RoomService.java
@@ -21,4 +21,6 @@ public interface RoomService {
     RoomDetailResponseDto getRoomDetailShortUuid(String roomUuid);
 
     RoomDetailResponseDto startCodingTest(String roomUuid);
+
+    void completeSolveHistory(String roomUuid);
 }

--- a/src/main/java/ei/algobaroapi/domain/room/service/RoomServiceImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/room/service/RoomServiceImpl.java
@@ -71,18 +71,22 @@ public class RoomServiceImpl implements RoomService {
     }
 
     @Override
-    public RoomDetailResponseDto getRoomByRoomUuid(String roomShortUuid) {
-        Room findRoom = roomRepository.findByRoomUuidStartingWith(roomShortUuid)
-                .orElseThrow(() -> RoomNotFoundException.of(RoomErrorCode.ROOM_NOT_FOUND));
+    public RoomDetailResponseDto getRoomDetailShortUuid(String roomShortUuid) {
+        Room findRoom = getRoomByShortUuid(roomShortUuid);
 
         return RoomDetailResponseDto.of(findRoom, getRoomMembersByRoomId(findRoom.getId()));
     }
 
     @Override
+    public Room getRoomByShortUuid(String roomShortUuid) {
+        return roomRepository.findByRoomUuidStartingWith(roomShortUuid)
+                .orElseThrow(() -> RoomNotFoundException.of(RoomErrorCode.ROOM_NOT_FOUND));
+    }
+
+    @Override
     @Transactional
     public RoomDetailResponseDto startCodingTest(String roomShortUuid) {
-        Room room = roomRepository.findByRoomUuidStartingWith(roomShortUuid)
-                .orElseThrow(() -> RoomNotFoundException.of(RoomErrorCode.ROOM_NOT_FOUND));
+        Room room = getRoomByShortUuid(roomShortUuid);
         Long roomId = room.getId();
 
         List<RoomMember> roomMembers = roomMemberService.getByRoomIdAllReady(roomId);

--- a/src/main/java/ei/algobaroapi/domain/room/service/RoomServiceImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/room/service/RoomServiceImpl.java
@@ -77,8 +77,7 @@ public class RoomServiceImpl implements RoomService {
         return RoomDetailResponseDto.of(findRoom, getRoomMembersByRoomId(findRoom.getId()));
     }
 
-    @Override
-    public Room getRoomByShortUuid(String roomShortUuid) {
+    private Room getRoomByShortUuid(String roomShortUuid) {
         return roomRepository.findByRoomUuidStartingWith(roomShortUuid)
                 .orElseThrow(() -> RoomNotFoundException.of(RoomErrorCode.ROOM_NOT_FOUND));
     }

--- a/src/main/java/ei/algobaroapi/domain/room_member/controller/RoomMemberControllerDocImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/controller/RoomMemberControllerDocImpl.java
@@ -35,13 +35,6 @@ public class RoomMemberControllerDocImpl implements RoomMemberControllerDoc {
         return roomMemberService.validateEnterRoom(shortUuid, joinRoomRequestDto.getPassword(), member);
     }
 
-    @PostMapping("/rooms-ready/{roomId}")
-    @PreAuthorize("hasRole('USER')")
-    public RoomMemberResponseDto changeReadyStatus(@PathVariable(name = "roomId") Long roomId,
-            @AuthenticationPrincipal Member member) {
-        return roomMemberService.changeReadyStatus(roomId, member.getId());
-    }
-
     @Override
     @PostMapping("/rooms/manual-change-host")
     public RoomHostManualResponseDto changeHostManually(

--- a/src/main/java/ei/algobaroapi/domain/room_member/controller/RoomMemberControllerDocImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/controller/RoomMemberControllerDocImpl.java
@@ -27,12 +27,12 @@ public class RoomMemberControllerDocImpl implements RoomMemberControllerDoc {
     private final RoomMemberService roomMemberService;
 
     @Override
-    @PostMapping("/rooms-join/{roomId}")
+    @PostMapping("/rooms-join/{shortUuid}")
     @PreAuthorize("hasRole('USER')")
-    public List<RoomMemberResponseDto> joinRoomByRoomId(@PathVariable(name = "roomId") Long roomId,
+    public List<RoomMemberResponseDto> joinRoomByRoomId(@PathVariable(name = "shortUuid") String shortUuid,
             @RequestBody JoinRoomRequestDto joinRoomRequestDto,
             @AuthenticationPrincipal Member member) {
-        return roomMemberService.joinRoomByRoomId(roomId, joinRoomRequestDto.getPassword(), member);
+        return roomMemberService.joinRoomByRoomShortUuid(shortUuid, joinRoomRequestDto.getPassword(), member);
     }
 
     @PostMapping("/rooms-ready/{roomId}")

--- a/src/main/java/ei/algobaroapi/domain/room_member/controller/RoomMemberControllerDocImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/controller/RoomMemberControllerDocImpl.java
@@ -27,12 +27,12 @@ public class RoomMemberControllerDocImpl implements RoomMemberControllerDoc {
     private final RoomMemberService roomMemberService;
 
     @Override
-    @PostMapping("/rooms-join/{shortUuid}")
+    @PostMapping("/rooms/{shortUuid}/validate-enter")
     @PreAuthorize("hasRole('USER')")
-    public List<RoomMemberResponseDto> joinRoomByRoomId(@PathVariable(name = "shortUuid") String shortUuid,
+    public List<RoomMemberResponseDto> validateEnterRoom(@PathVariable(name = "shortUuid") String shortUuid,
             @RequestBody JoinRoomRequestDto joinRoomRequestDto,
             @AuthenticationPrincipal Member member) {
-        return roomMemberService.joinRoomByRoomShortUuid(shortUuid, joinRoomRequestDto.getPassword(), member);
+        return roomMemberService.validateEnterRoom(shortUuid, joinRoomRequestDto.getPassword(), member);
     }
 
     @PostMapping("/rooms-ready/{roomId}")

--- a/src/main/java/ei/algobaroapi/domain/room_member/controller/RoomMemberControllerDocImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/controller/RoomMemberControllerDocImpl.java
@@ -34,11 +34,4 @@ public class RoomMemberControllerDocImpl implements RoomMemberControllerDoc {
             @AuthenticationPrincipal Member member) {
         return roomMemberService.validateEnterRoom(shortUuid, joinRoomRequestDto.getPassword(), member);
     }
-
-    @Override
-    @PostMapping("/rooms/manual-change-host")
-    public RoomHostManualResponseDto changeHostManually(
-            @RequestBody HostManualChangeRequestDto hostManualChangeRequestDto) {
-        return roomMemberService.changeHostManually(hostManualChangeRequestDto);
-    }
 }

--- a/src/main/java/ei/algobaroapi/domain/room_member/controller/RoomMemberControllerDocImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/controller/RoomMemberControllerDocImpl.java
@@ -41,11 +41,4 @@ public class RoomMemberControllerDocImpl implements RoomMemberControllerDoc {
             @RequestBody HostManualChangeRequestDto hostManualChangeRequestDto) {
         return roomMemberService.changeHostManually(hostManualChangeRequestDto);
     }
-
-    @Override
-    @PostMapping("/rooms/auto-change-host")
-    public RoomHostAutoChangeResponseDto changeHostAutomatically(
-            @RequestBody HostAutoChangeRequestDto hostAutoChangeRequestDto) {
-        return roomMemberService.changeHostAutomatically(hostAutoChangeRequestDto);
-    }
 }

--- a/src/main/java/ei/algobaroapi/domain/room_member/domain/RoomMember.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/domain/RoomMember.java
@@ -67,8 +67,12 @@ public class RoomMember extends BaseEntity {
         this.isReady = false;
     }
 
-    public void changeReadyStatus() {
-        this.isReady = !this.isReady;
+    public void markReady() {
+        this.isReady = true;
+    }
+
+    public void markUnready() {
+        this.isReady = false;
     }
 
     public boolean isParticipant() {

--- a/src/main/java/ei/algobaroapi/domain/room_member/dto/request/HostManualChangeRequestDto.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/dto/request/HostManualChangeRequestDto.java
@@ -13,8 +13,8 @@ public class HostManualChangeRequestDto {
     private String roomShortUuid;
 
     @Schema(description = "현재 방장 번호", example = "1")
-    private Long hostId;
+    private Long hostMemberId;
 
     @Schema(description = "현재 참여자 번호", example = "2")
-    private Long organizerId;
+    private Long organizerMemberId;
 }

--- a/src/main/java/ei/algobaroapi/domain/room_member/dto/request/HostManualChangeRequestDto.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/dto/request/HostManualChangeRequestDto.java
@@ -10,7 +10,7 @@ import lombok.Getter;
 public class HostManualChangeRequestDto {
 
     @Schema(description = "방 번호", example = "4")
-    private Long roomId;
+    private String roomShortUuid;
 
     @Schema(description = "현재 방장 번호", example = "1")
     private Long hostId;

--- a/src/main/java/ei/algobaroapi/domain/room_member/dto/response/RoomExitResponse.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/dto/response/RoomExitResponse.java
@@ -1,0 +1,30 @@
+package ei.algobaroapi.domain.room_member.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Schema(description = "방 퇴장 시 정보")
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class RoomExitResponse {
+
+    @Schema(description = "방 id", example = "30")
+    private final Long roomId;
+
+    // 방장 변경 여부
+    @Schema(description = "방장 변경 여부", example = "true")
+    private final boolean isHostChanged;
+
+    @Schema(description = "변경 된 방장의 방-멤버 번호", example = "2")
+    private final Long newHostId;
+
+    public static RoomExitResponse changedHost(Long roomId, Long newHostId) {
+        return new RoomExitResponse(roomId, true, newHostId);
+    }
+
+    public static RoomExitResponse notChangedHost(Long roomId) {
+        return new RoomExitResponse(roomId, false, null);
+    }
+}

--- a/src/main/java/ei/algobaroapi/domain/room_member/dto/response/RoomExitResponse.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/dto/response/RoomExitResponse.java
@@ -17,7 +17,7 @@ public class RoomExitResponse {
     @Schema(description = "방장 변경 여부", example = "true")
     private final boolean isHostChanged;
 
-    @Schema(description = "변경 된 방장의 방-멤버 번호", example = "2")
+    @Schema(description = "변경 된 방장의 멤버 id", example = "2")
     private final Long newHostId;
 
     public static RoomExitResponse changedHost(Long roomId, Long newHostId) {

--- a/src/main/java/ei/algobaroapi/domain/room_member/dto/response/RoomHostAutoChangeResponseDto.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/dto/response/RoomHostAutoChangeResponseDto.java
@@ -13,7 +13,7 @@ public class RoomHostAutoChangeResponseDto {
     @Schema(description = "방 번호", example = "30")
     private Long roomId;
 
-    @Schema(description = "현재 방장의 방-멤버 번호", example = "2")
+    @Schema(description = "현재 방장의 멤버 id", example = "2")
     private Long newHostId;
 
     @Schema(description = "현재 방장의 닉네임", example = "test2")
@@ -22,7 +22,7 @@ public class RoomHostAutoChangeResponseDto {
     public static RoomHostAutoChangeResponseDto of(Long roomId, RoomMember newHost) {
         return RoomHostAutoChangeResponseDto.builder()
                 .roomId(roomId)
-                .newHostId(newHost.getId())
+                .newHostId(newHost.getMember().getId())
                 .newHostNickname(newHost.getMember().getNickname())
                 .build();
     }

--- a/src/main/java/ei/algobaroapi/domain/room_member/dto/response/RoomHostManualResponseDto.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/dto/response/RoomHostManualResponseDto.java
@@ -11,7 +11,7 @@ import lombok.Getter;
 public class RoomHostManualResponseDto {
 
     @Schema(description = "방 번호", example = "30")
-    private Long roomId;
+    private String roomShortUuid;
 
     @Schema(description = "이전 방장의 방-멤버 번호", example = "1")
     private Long previousHostId;
@@ -25,9 +25,9 @@ public class RoomHostManualResponseDto {
     @Schema(description = "현재 방장의 닉네임", example = "test2")
     private String newHostNickname;
 
-    public static RoomHostManualResponseDto of(Long roomId, RoomMember previousHost, RoomMember newHost) {
+    public static RoomHostManualResponseDto of(String roomShortUuid, RoomMember previousHost, RoomMember newHost) {
         return RoomHostManualResponseDto.builder()
-                .roomId(roomId)
+                .roomShortUuid(roomShortUuid)
                 .previousHostId(previousHost.getId())
                 .previousHostNickname(previousHost.getMember().getNickname())
                 .newHostId(newHost.getId())

--- a/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberService.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberService.java
@@ -5,6 +5,7 @@ import ei.algobaroapi.domain.room.domain.Room;
 import ei.algobaroapi.domain.room_member.domain.RoomMember;
 import ei.algobaroapi.domain.room_member.dto.request.HostAutoChangeRequestDto;
 import ei.algobaroapi.domain.room_member.dto.request.HostManualChangeRequestDto;
+import ei.algobaroapi.domain.room_member.dto.response.RoomExitResponse;
 import ei.algobaroapi.domain.room_member.dto.response.RoomHostAutoChangeResponseDto;
 import ei.algobaroapi.domain.room_member.dto.response.RoomHostManualResponseDto;
 import ei.algobaroapi.domain.room_member.dto.response.RoomMemberResponseDto;
@@ -30,5 +31,5 @@ public interface RoomMemberService {
 
     List<RoomMember> getByRoomIdAllReady(Long roomId);
 
-    List<RoomMemberResponseDto> exitRoomByMemberId(Long memberId);
+    RoomExitResponse exitRoomByMemberId(Long memberId);
 }

--- a/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberService.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberService.java
@@ -20,9 +20,9 @@ public interface RoomMemberService {
 
     List<RoomMemberResponseDto> getRoomMembersByRoomId(Long roomId);
 
-    RoomMemberResponseDto chageStatusToReady(Long roomId, Long memberId);
+    RoomMemberResponseDto chageStatusToReady(String roomShortUuid, Long memberId);
 
-    RoomMemberResponseDto chageStatusToUnready(Long roomId, Long memberId);
+    RoomMemberResponseDto chageStatusToUnready(String roomShortUuid, Long memberId);
 
     RoomHostManualResponseDto changeHostManually(HostManualChangeRequestDto hostManualChangeRequestDto);
 

--- a/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberService.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberService.java
@@ -16,6 +16,8 @@ public interface RoomMemberService {
 
     List<RoomMemberResponseDto> joinRoomByRoomShortUuid(String shortUuid, String password, Member member);
 
+    List<RoomMemberResponseDto> validateEnterRoom(String shortUuid, String password, Member member);
+
     List<RoomMemberResponseDto> getRoomMembersByRoomId(Long roomId);
 
     RoomMemberResponseDto changeReadyStatus(Long roomId, Long memberId);

--- a/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberService.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberService.java
@@ -20,7 +20,9 @@ public interface RoomMemberService {
 
     List<RoomMemberResponseDto> getRoomMembersByRoomId(Long roomId);
 
-    RoomMemberResponseDto changeReadyStatus(Long roomId, Long memberId);
+    RoomMemberResponseDto chageStatusToReady(Long roomId, Long memberId);
+
+    RoomMemberResponseDto chageStatusToUnready(Long roomId, Long memberId);
 
     RoomHostManualResponseDto changeHostManually(HostManualChangeRequestDto hostManualChangeRequestDto);
 

--- a/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberService.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberService.java
@@ -14,7 +14,7 @@ public interface RoomMemberService {
 
     List<RoomMemberResponseDto> createRoomByRoomId(Room room, Member member);
 
-    List<RoomMemberResponseDto> joinRoomByRoomId(Long roomId, String password, Member member);
+    List<RoomMemberResponseDto> joinRoomByRoomShortUuid(String shortUuid, String password, Member member);
 
     List<RoomMemberResponseDto> getRoomMembersByRoomId(Long roomId);
 

--- a/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberService.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberService.java
@@ -14,7 +14,7 @@ public interface RoomMemberService {
 
     List<RoomMemberResponseDto> createRoomByRoomId(Room room, Member member);
 
-    List<RoomMemberResponseDto> joinRoomByRoomShortUuid(String shortUuid, String password, Member member);
+    void joinRoomByRoomShortUuid(String shortUuid, Member member);
 
     List<RoomMemberResponseDto> validateEnterRoom(String shortUuid, String password, Member member);
 

--- a/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberServiceImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberServiceImpl.java
@@ -57,6 +57,13 @@ public class RoomMemberServiceImpl implements RoomMemberService {
         Room room = roomRepository.findByRoomUuidStartingWith(shortUuid)
                 .orElseThrow(() -> RoomNotFoundException.of(RoomErrorCode.ROOM_NOT_FOUND));
 
+        // 이미 방에 존재하면 아무것도 안 함
+        if (roomMemberRepository
+                .findRoomMemberByRoomIdAndMemberId(room.getId(), member.getId())
+                .isPresent()) {
+            return;
+        }
+
         RoomMember roomMember = RoomMember.builder()
                 .room(room)
                 .member(member)

--- a/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberServiceImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberServiceImpl.java
@@ -136,7 +136,7 @@ public class RoomMemberServiceImpl implements RoomMemberService {
 
         organizer.changeRoleToHost();
 
-        return RoomHostManualResponseDto.of(hostManualChangeRequestDto.getRoomId(), host,
+        return RoomHostManualResponseDto.of(hostManualChangeRequestDto.getRoomShortUuid(), host,
                 organizer);
     }
 

--- a/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberServiceImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberServiceImpl.java
@@ -89,13 +89,26 @@ public class RoomMemberServiceImpl implements RoomMemberService {
 
     @Override
     @Transactional
-    public RoomMemberResponseDto changeReadyStatus(Long roomId, Long memberId) {
+    public RoomMemberResponseDto chageStatusToReady(Long roomId, Long memberId) {
         RoomMember roomMember = roomMemberRepository.findRoomMemberByRoomIdAndMemberId(roomId,
                         memberId)
                 .orElseThrow(() -> RoomMemberNotFoundException.of(
                         RoomMemberErrorCode.ROOM_MEMBER_ERROR_CODE));
 
-        roomMember.changeReadyStatus();
+        roomMember.markReady();
+
+        return RoomMemberResponseDto.of(roomMember);
+    }
+
+    @Override
+    @Transactional
+    public RoomMemberResponseDto chageStatusToUnready(Long roomId, Long memberId) {
+        RoomMember roomMember = roomMemberRepository.findRoomMemberByRoomIdAndMemberId(roomId,
+                        memberId)
+                .orElseThrow(() -> RoomMemberNotFoundException.of(
+                        RoomMemberErrorCode.ROOM_MEMBER_ERROR_CODE));
+
+        roomMember.markUnready();
 
         return RoomMemberResponseDto.of(roomMember);
     }

--- a/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberServiceImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberServiceImpl.java
@@ -75,6 +75,19 @@ public class RoomMemberServiceImpl implements RoomMemberService {
     }
 
     @Override
+    @Transactional
+    public List<RoomMemberResponseDto> validateEnterRoom(String shortUuid, String password,
+            Member member) {
+        Room room = roomService.getRoomByShortUuid(shortUuid);
+
+        validateConditionToJoinRoom(room, password);
+
+        return roomMemberRepository.findByRoomId(room.getId()).stream()
+                .map(RoomMemberResponseDto::of)
+                .toList();
+    }
+
+    @Override
     public List<RoomMemberResponseDto> getRoomMembersByRoomId(Long roomId) {
         return roomMemberRepository.findByRoomId(roomId).stream()
                 .map(RoomMemberResponseDto::of)

--- a/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberServiceImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberServiceImpl.java
@@ -89,8 +89,10 @@ public class RoomMemberServiceImpl implements RoomMemberService {
 
     @Override
     @Transactional
-    public RoomMemberResponseDto chageStatusToReady(Long roomId, Long memberId) {
-        RoomMember roomMember = roomMemberRepository.findRoomMemberByRoomIdAndMemberId(roomId,
+    public RoomMemberResponseDto chageStatusToReady(String roomShortUuid, Long memberId) {
+        Room room = roomRepository.findByRoomUuidStartingWith(roomShortUuid)
+                .orElseThrow(() -> RoomNotFoundException.of(RoomErrorCode.ROOM_NOT_FOUND));
+        RoomMember roomMember = roomMemberRepository.findRoomMemberByRoomIdAndMemberId(room.getId(),
                         memberId)
                 .orElseThrow(() -> RoomMemberNotFoundException.of(
                         RoomMemberErrorCode.ROOM_MEMBER_ERROR_CODE));
@@ -102,8 +104,10 @@ public class RoomMemberServiceImpl implements RoomMemberService {
 
     @Override
     @Transactional
-    public RoomMemberResponseDto chageStatusToUnready(Long roomId, Long memberId) {
-        RoomMember roomMember = roomMemberRepository.findRoomMemberByRoomIdAndMemberId(roomId,
+    public RoomMemberResponseDto chageStatusToUnready(String roomShortUuid, Long memberId) {
+        Room room = roomRepository.findByRoomUuidStartingWith(roomShortUuid)
+                .orElseThrow(() -> RoomNotFoundException.of(RoomErrorCode.ROOM_NOT_FOUND));
+        RoomMember roomMember = roomMemberRepository.findRoomMemberByRoomIdAndMemberId(room.getId(),
                         memberId)
                 .orElseThrow(() -> RoomMemberNotFoundException.of(
                         RoomMemberErrorCode.ROOM_MEMBER_ERROR_CODE));

--- a/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberServiceImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberServiceImpl.java
@@ -81,7 +81,12 @@ public class RoomMemberServiceImpl implements RoomMemberService {
         Room room = roomRepository.findByRoomUuidStartingWith(shortUuid)
                 .orElseThrow(() -> RoomNotFoundException.of(RoomErrorCode.ROOM_NOT_FOUND));
 
-        validateConditionToJoinRoom(room, password);
+        // 만약 방에 이미 Member가 존재하면(재참가) validate를 하지 않고 참여하도록 함
+        if (roomMemberRepository
+                .findRoomMemberByRoomIdAndMemberId(room.getId(), member.getId())
+                .isEmpty()) {
+            validateConditionToJoinRoom(room, password);
+        }
 
         return roomMemberRepository.findByRoomId(room.getId()).stream()
                 .map(RoomMemberResponseDto::of)

--- a/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberServiceImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberServiceImpl.java
@@ -138,12 +138,12 @@ public class RoomMemberServiceImpl implements RoomMemberService {
                         hostManualChangeRequestDto.getRoomShortUuid())
                 .orElseThrow(() -> RoomNotFoundException.of(RoomErrorCode.ROOM_NOT_FOUND));
         RoomMember host = roomMemberRepository.findRoomMemberByRoomIdAndMemberId(room.getId(),
-                        hostManualChangeRequestDto.getHostId())
+                        hostManualChangeRequestDto.getHostMemberId())
                 .orElseThrow(() -> RoomMemberNotFoundException.of(
                         RoomMemberErrorCode.ROOM_MEMBER_ERROR_CODE));
 
         RoomMember organizer = roomMemberRepository.findRoomMemberByRoomIdAndMemberId(room.getId(),
-                        hostManualChangeRequestDto.getOrganizerId())
+                        hostManualChangeRequestDto.getOrganizerMemberId())
                 .orElseThrow(() -> RoomMemberNotFoundException.of(
                         RoomMemberErrorCode.ROOM_MEMBER_ERROR_CODE));
 

--- a/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberServiceImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberServiceImpl.java
@@ -5,7 +5,6 @@ import ei.algobaroapi.domain.room.domain.Room;
 import ei.algobaroapi.domain.room.domain.RoomRepository;
 import ei.algobaroapi.domain.room.exception.RoomNotFoundException;
 import ei.algobaroapi.domain.room.exception.common.RoomErrorCode;
-import ei.algobaroapi.domain.room.service.RoomService;
 import ei.algobaroapi.domain.room_member.domain.RoomMember;
 import ei.algobaroapi.domain.room_member.domain.RoomMemberRepository;
 import ei.algobaroapi.domain.room_member.domain.RoomMemberRole;
@@ -32,7 +31,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class RoomMemberServiceImpl implements RoomMemberService {
 
     private final RoomRepository roomRepository;
-    private final RoomService roomService;
     private final RoomMemberRepository roomMemberRepository;
 
     @Override
@@ -55,7 +53,8 @@ public class RoomMemberServiceImpl implements RoomMemberService {
     @Override
     @Transactional
     public void joinRoomByRoomShortUuid(String shortUuid, Member member) {
-        Room room = roomService.getRoomByShortUuid(shortUuid);
+        Room room = roomRepository.findByRoomUuidStartingWith(shortUuid)
+                .orElseThrow(() -> RoomNotFoundException.of(RoomErrorCode.ROOM_NOT_FOUND));
 
         RoomMember roomMember = RoomMember.builder()
                 .room(room)
@@ -71,7 +70,8 @@ public class RoomMemberServiceImpl implements RoomMemberService {
     @Transactional
     public List<RoomMemberResponseDto> validateEnterRoom(String shortUuid, String password,
             Member member) {
-        Room room = roomService.getRoomByShortUuid(shortUuid);
+        Room room = roomRepository.findByRoomUuidStartingWith(shortUuid)
+                .orElseThrow(() -> RoomNotFoundException.of(RoomErrorCode.ROOM_NOT_FOUND));
 
         validateConditionToJoinRoom(room, password);
 

--- a/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberServiceImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberServiceImpl.java
@@ -54,11 +54,8 @@ public class RoomMemberServiceImpl implements RoomMemberService {
 
     @Override
     @Transactional
-    public List<RoomMemberResponseDto> joinRoomByRoomShortUuid(String shortUuid, String password,
-            Member member) {
+    public void joinRoomByRoomShortUuid(String shortUuid, Member member) {
         Room room = roomService.getRoomByShortUuid(shortUuid);
-
-        validateConditionToJoinRoom(room, password);
 
         RoomMember roomMember = RoomMember.builder()
                 .room(room)
@@ -68,10 +65,6 @@ public class RoomMemberServiceImpl implements RoomMemberService {
                 .build();
 
         roomMemberRepository.save(roomMember);
-
-        return roomMemberRepository.findByRoomId(room.getId()).stream()
-                .map(RoomMemberResponseDto::of)
-                .toList();
     }
 
     @Override
@@ -115,7 +108,8 @@ public class RoomMemberServiceImpl implements RoomMemberService {
                 .orElseThrow(() -> RoomMemberNotFoundException.of(
                         RoomMemberErrorCode.ROOM_MEMBER_ERROR_CODE));
 
-        RoomMember organizer = roomMemberRepository.findById(hostManualChangeRequestDto.getOrganizerId())
+        RoomMember organizer = roomMemberRepository.findById(
+                        hostManualChangeRequestDto.getOrganizerId())
                 .orElseThrow(() -> RoomMemberNotFoundException.of(
                         RoomMemberErrorCode.ROOM_MEMBER_ERROR_CODE));
 
@@ -125,12 +119,14 @@ public class RoomMemberServiceImpl implements RoomMemberService {
 
         organizer.changeRoleToHost();
 
-        return RoomHostManualResponseDto.of(hostManualChangeRequestDto.getRoomId(), host, organizer);
+        return RoomHostManualResponseDto.of(hostManualChangeRequestDto.getRoomId(), host,
+                organizer);
     }
 
     @Override
     @Transactional
-    public RoomHostAutoChangeResponseDto changeHostAutomatically(HostAutoChangeRequestDto hostAutoChangeRequestDto) {
+    public RoomHostAutoChangeResponseDto changeHostAutomatically(
+            HostAutoChangeRequestDto hostAutoChangeRequestDto) {
         Long roomId = hostAutoChangeRequestDto.getRoomId();
 
         RoomMember newHost = roomMemberRepository.findByRoomId(roomId).stream()

--- a/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberServiceImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberServiceImpl.java
@@ -5,6 +5,7 @@ import ei.algobaroapi.domain.room.domain.Room;
 import ei.algobaroapi.domain.room.domain.RoomRepository;
 import ei.algobaroapi.domain.room.exception.RoomNotFoundException;
 import ei.algobaroapi.domain.room.exception.common.RoomErrorCode;
+import ei.algobaroapi.domain.room.service.RoomService;
 import ei.algobaroapi.domain.room_member.domain.RoomMember;
 import ei.algobaroapi.domain.room_member.domain.RoomMemberRepository;
 import ei.algobaroapi.domain.room_member.domain.RoomMemberRole;
@@ -31,6 +32,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class RoomMemberServiceImpl implements RoomMemberService {
 
     private final RoomRepository roomRepository;
+    private final RoomService roomService;
     private final RoomMemberRepository roomMemberRepository;
 
     @Override
@@ -52,10 +54,9 @@ public class RoomMemberServiceImpl implements RoomMemberService {
 
     @Override
     @Transactional
-    public List<RoomMemberResponseDto> joinRoomByRoomId(Long roomId, String password,
+    public List<RoomMemberResponseDto> joinRoomByRoomShortUuid(String shortUuid, String password,
             Member member) {
-        Room room = roomRepository.findById(roomId).orElseThrow(() -> RoomNotFoundException.of(
-                RoomErrorCode.ROOM_NOT_FOUND));
+        Room room = roomService.getRoomByShortUuid(shortUuid);
 
         validateConditionToJoinRoom(room, password);
 
@@ -68,7 +69,7 @@ public class RoomMemberServiceImpl implements RoomMemberService {
 
         roomMemberRepository.save(roomMember);
 
-        return roomMemberRepository.findByRoomId(roomId).stream()
+        return roomMemberRepository.findByRoomId(room.getId()).stream()
                 .map(RoomMemberResponseDto::of)
                 .toList();
     }

--- a/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberServiceImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberServiceImpl.java
@@ -198,7 +198,10 @@ public class RoomMemberServiceImpl implements RoomMemberService {
                 .orElseThrow(() -> RoomMemberNotFoundException.of(
                         RoomMemberErrorCode.ROOM_MEMBER_ERROR_CODE));
 
-        roomMemberRepository.delete(roomMember);
+        // 진행 중인 방인 경우 나가더라도 재입장을 위해 삭제하지 않음
+        if (!findRoom.isRunning()) {
+            roomMemberRepository.delete(roomMember);
+        }
 
         // 만약 방이 빈 방이 되었을 경우 방을 삭제
         if (checkRoomMemberExistInRoom(findRoom)) {

--- a/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberServiceImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/room_member/service/RoomMemberServiceImpl.java
@@ -122,11 +122,15 @@ public class RoomMemberServiceImpl implements RoomMemberService {
     @Transactional
     public RoomHostManualResponseDto changeHostManually(
             HostManualChangeRequestDto hostManualChangeRequestDto) {
-        RoomMember host = roomMemberRepository.findById(hostManualChangeRequestDto.getHostId())
+        Room room = roomRepository.findByRoomUuidStartingWith(
+                        hostManualChangeRequestDto.getRoomShortUuid())
+                .orElseThrow(() -> RoomNotFoundException.of(RoomErrorCode.ROOM_NOT_FOUND));
+        RoomMember host = roomMemberRepository.findRoomMemberByRoomIdAndMemberId(room.getId(),
+                        hostManualChangeRequestDto.getHostId())
                 .orElseThrow(() -> RoomMemberNotFoundException.of(
                         RoomMemberErrorCode.ROOM_MEMBER_ERROR_CODE));
 
-        RoomMember organizer = roomMemberRepository.findById(
+        RoomMember organizer = roomMemberRepository.findRoomMemberByRoomIdAndMemberId(room.getId(),
                         hostManualChangeRequestDto.getOrganizerId())
                 .orElseThrow(() -> RoomMemberNotFoundException.of(
                         RoomMemberErrorCode.ROOM_MEMBER_ERROR_CODE));

--- a/src/main/java/ei/algobaroapi/domain/solve/controller/SolveController.java
+++ b/src/main/java/ei/algobaroapi/domain/solve/controller/SolveController.java
@@ -63,13 +63,6 @@ public class SolveController implements SolveControllerDoc {
     }
 
     @Override
-    @PostMapping("/solves/complete/{roomUuid}")
-    public void completeSolveHistory(@PathVariable("roomUuid") String roomUuid) {
-        // TODO: 권한 체크 필요
-        solveHistoryService.completeSolveHistory(roomUuid);
-    }
-
-    @Override
     @GetMapping("/solves/result/{roomUuid}")
     public SolveResultResponse getSolveResultInRoom(@PathVariable("roomUuid") String roomUuid) {
         return solveHistoryService.getSolveResultInRoom(roomUuid);

--- a/src/main/java/ei/algobaroapi/domain/solve/service/SolveHistoryService.java
+++ b/src/main/java/ei/algobaroapi/domain/solve/service/SolveHistoryService.java
@@ -18,8 +18,6 @@ public interface SolveHistoryService {
 
     SolveHistoryDetailResponse getHistoryDetail(Long memberId, Long solveId);
 
-    void completeSolveHistory(String roomUuid);
-
     void updateSolveHistoryCode(Long memberId, String roomUuid, String language, String code);
 
     SolveResultResponse getSolveResultInRoom(String roomUuid);

--- a/src/main/java/ei/algobaroapi/domain/solve/service/SolveHistoryService.java
+++ b/src/main/java/ei/algobaroapi/domain/solve/service/SolveHistoryService.java
@@ -6,6 +6,7 @@ import ei.algobaroapi.domain.solve.dto.response.SolveHistoryDetailResponse;
 import ei.algobaroapi.domain.solve.dto.response.SolveHistoryResponse;
 import ei.algobaroapi.domain.solve.dto.response.SolveResultResponse;
 import ei.algobaroapi.global.dto.PageResponse;
+import java.util.List;
 
 public interface SolveHistoryService {
 
@@ -24,4 +25,6 @@ public interface SolveHistoryService {
     SolveResultResponse getSolveResultInRoom(String roomUuid);
 
     void setUpSolveHistory(Long memberId, String roomUuid, String problemLink);
+
+    List<SolveHistory> getSolveHistoryList(String roomUuid);
 }

--- a/src/main/java/ei/algobaroapi/domain/solve/service/SolveHistoryServiceImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/solve/service/SolveHistoryServiceImpl.java
@@ -87,24 +87,6 @@ public class SolveHistoryServiceImpl implements SolveHistoryService {
     }
 
     @Override
-    @Transactional
-    public void completeSolveHistory(String roomUuid) {
-        // TODO: 트랜잭션 내 API 호출 분리 필요
-        List<SolveHistory> solveHistoryList = this.getSolveHistoryList(roomUuid);
-
-        solveHistoryList.forEach(solveHistory -> {
-            SolveStatus solveStatus = problemService.checkSolveResult(
-                    ProblemSolveRequest.builder()
-                            .problemLink(solveHistory.getProblemLink())
-                            .userBojId(solveHistory.getMember().getBojId())
-                            .build()
-            );
-
-            solveHistory.complete(solveStatus);
-        });
-    }
-
-    @Override
     public SolveResultResponse getSolveResultInRoom(String roomUuid) {
         List<SolveHistory> solveHistoryList = this.getSolveHistoryList(roomUuid);
 

--- a/src/main/java/ei/algobaroapi/domain/solve/service/SolveHistoryServiceImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/solve/service/SolveHistoryServiceImpl.java
@@ -132,7 +132,8 @@ public class SolveHistoryServiceImpl implements SolveHistoryService {
         solveHistoryRepository.save(createSolveHistory);
     }
 
-    private List<SolveHistory> getSolveHistoryList(String roomUuid) {
+    @Override
+    public List<SolveHistory> getSolveHistoryList(String roomUuid) {
         return solveHistoryRepository.findByRoomUuidWithMember(roomUuid);
     }
 }

--- a/src/main/java/ei/algobaroapi/global/config/swaggerdoc/RoomMemberControllerDoc.java
+++ b/src/main/java/ei/algobaroapi/global/config/swaggerdoc/RoomMemberControllerDoc.java
@@ -21,7 +21,7 @@ public interface RoomMemberControllerDoc {
     @ApiResponse(responseCode = "E05302", description = "모집 중인 방이 아닙니다.")
     @ApiResponse(responseCode = "E05303", description = "입력한 비밀번호와 방 비밀번호가 일치하지 않습니다.")
     @ApiResponse(responseCode = "E05304", description = "방 참여 가능 인원이 가득 찼습니다.")
-    List<RoomMemberResponseDto> joinRoomByRoomId(Long roomId, JoinRoomRequestDto joinRoomRequestDto,
+    List<RoomMemberResponseDto> joinRoomByRoomId(String shortUuid, JoinRoomRequestDto joinRoomRequestDto,
             Member member);
 
     @Operation(summary = "준비 상태 변경", description = "방 참여자의 준비 상태를 변경합니다. true -> false, false -> true")

--- a/src/main/java/ei/algobaroapi/global/config/swaggerdoc/RoomMemberControllerDoc.java
+++ b/src/main/java/ei/algobaroapi/global/config/swaggerdoc/RoomMemberControllerDoc.java
@@ -24,11 +24,6 @@ public interface RoomMemberControllerDoc {
     List<RoomMemberResponseDto> validateEnterRoom(String shortUuid, JoinRoomRequestDto joinRoomRequestDto,
             Member member);
 
-    @Operation(summary = "준비 상태 변경", description = "방 참여자의 준비 상태를 변경합니다. true -> false, false -> true")
-    @ApiResponse(responseCode = "200", description = "준비 상태 변경에 성공하였습니다.")
-    @ApiResponse(responseCode = "E05301", description = "해당 방에 멤버를 찾지 못했습니다.")
-    RoomMemberResponseDto changeReadyStatus(Long roomId, Member member);
-
     @Operation(summary = "방장 수동 변경", description = "현재 방장이 참여자에게 방장 권한을 위임합니다.")
     @ApiResponse(responseCode = "200", description = "방장 수동 위임에 성공하였습니다.")
     @ApiResponse(responseCode = "E05301", description = "해당 방에 멤버를 찾지 못했습니다.")

--- a/src/main/java/ei/algobaroapi/global/config/swaggerdoc/RoomMemberControllerDoc.java
+++ b/src/main/java/ei/algobaroapi/global/config/swaggerdoc/RoomMemberControllerDoc.java
@@ -23,11 +23,4 @@ public interface RoomMemberControllerDoc {
     @ApiResponse(responseCode = "E05304", description = "방 참여 가능 인원이 가득 찼습니다.")
     List<RoomMemberResponseDto> validateEnterRoom(String shortUuid, JoinRoomRequestDto joinRoomRequestDto,
             Member member);
-
-    @Operation(summary = "방장 수동 변경", description = "현재 방장이 참여자에게 방장 권한을 위임합니다.")
-    @ApiResponse(responseCode = "200", description = "방장 수동 위임에 성공하였습니다.")
-    @ApiResponse(responseCode = "E05301", description = "해당 방에 멤버를 찾지 못했습니다.")
-    @ApiResponse(responseCode = "E05302", description = "방장 권한을 위임할 수 있는 권한을 가지고 있지 않습니다.")
-    @ApiResponse(responseCode = "E05303", description = "방장 권한을 위임 받을 수 있는 참여자가 아닙니다.")
-    RoomHostManualResponseDto changeHostManually(HostManualChangeRequestDto hostManualChangeRequestDto);
 }

--- a/src/main/java/ei/algobaroapi/global/config/swaggerdoc/RoomMemberControllerDoc.java
+++ b/src/main/java/ei/algobaroapi/global/config/swaggerdoc/RoomMemberControllerDoc.java
@@ -30,8 +30,4 @@ public interface RoomMemberControllerDoc {
     @ApiResponse(responseCode = "E05302", description = "방장 권한을 위임할 수 있는 권한을 가지고 있지 않습니다.")
     @ApiResponse(responseCode = "E05303", description = "방장 권한을 위임 받을 수 있는 참여자가 아닙니다.")
     RoomHostManualResponseDto changeHostManually(HostManualChangeRequestDto hostManualChangeRequestDto);
-
-    @Operation(summary = "방장 자동 변경", description = "현재 방장이 방을 나갔을 경우, 방에 참여한 순으로 방장을 새로 위임합니다.")
-    @ApiResponse(responseCode = "200", description = "방장 자동 위임에 성공하였습니다.")
-    RoomHostAutoChangeResponseDto changeHostAutomatically(HostAutoChangeRequestDto hostAutoChangeRequestDto);
 }

--- a/src/main/java/ei/algobaroapi/global/config/swaggerdoc/RoomMemberControllerDoc.java
+++ b/src/main/java/ei/algobaroapi/global/config/swaggerdoc/RoomMemberControllerDoc.java
@@ -16,12 +16,12 @@ import java.util.List;
 @SuppressWarnings("unused")
 public interface RoomMemberControllerDoc {
 
-    @Operation(summary = "방 참여", description = "생성된 방에 참여합니다.")
-    @ApiResponse(responseCode = "200", description = "방 참여에 성공하였습니다.")
+    @Operation(summary = "방 참여 전 검증", description = "방 참여 전 검증을 진행합니다.")
+    @ApiResponse(responseCode = "200", description = "방 참여 검증에 성공하였습니다. 소켓을 통해 채팅 방 참여 요청을 진행하시면 됩니다.")
     @ApiResponse(responseCode = "E05302", description = "모집 중인 방이 아닙니다.")
     @ApiResponse(responseCode = "E05303", description = "입력한 비밀번호와 방 비밀번호가 일치하지 않습니다.")
     @ApiResponse(responseCode = "E05304", description = "방 참여 가능 인원이 가득 찼습니다.")
-    List<RoomMemberResponseDto> joinRoomByRoomId(String shortUuid, JoinRoomRequestDto joinRoomRequestDto,
+    List<RoomMemberResponseDto> validateEnterRoom(String shortUuid, JoinRoomRequestDto joinRoomRequestDto,
             Member member);
 
     @Operation(summary = "준비 상태 변경", description = "방 참여자의 준비 상태를 변경합니다. true -> false, false -> true")

--- a/src/main/java/ei/algobaroapi/global/config/swaggerdoc/SolveControllerDoc.java
+++ b/src/main/java/ei/algobaroapi/global/config/swaggerdoc/SolveControllerDoc.java
@@ -35,10 +35,6 @@ public interface SolveControllerDoc {
     @ApiResponse(responseCode = "E02201", description = "해당 풀이 내역에 접근할 수 없습니다.", content = @Content)
     SolveHistoryDetailResponse getHistoryDetail(Member member, Long solveId);
 
-    @Operation(summary = "문제 풀이 종료", description = "문제 풀이를 종료합니다.")
-    @ApiResponse(responseCode = "201", description = "문제 풀이 종료 성공")
-    void completeSolveHistory(String roomUuid);
-
     @Operation(summary = "문제 풀이 결과 조회", description = "문제 풀이 종료 후 풀이 결과를 조회합니다.")
     @ApiResponse(responseCode = "200", description = "문제 풀이 결과 조회 성공")
     SolveResultResponse getSolveResultInRoom(String roomUuid);

--- a/src/main/java/ei/algobaroapi/global/jwt/JwtProvider.java
+++ b/src/main/java/ei/algobaroapi/global/jwt/JwtProvider.java
@@ -74,7 +74,7 @@ public class JwtProvider {
         return false;
     }
 
-    private String getUserEmailByToken(String token) {
+    public String getUserEmailByToken(String token) {
         return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody().getSubject();
     }
 }

--- a/src/main/java/ei/algobaroapi/global/socket/WebSocketChannelInterceptor.java
+++ b/src/main/java/ei/algobaroapi/global/socket/WebSocketChannelInterceptor.java
@@ -22,7 +22,8 @@ public class WebSocketChannelInterceptor implements ChannelInterceptor {
         final StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
 
         if (accessor.getCommand() == StompCommand.CONNECT ||
-                accessor.getCommand() == StompCommand.SUBSCRIBE) {
+                accessor.getCommand() == StompCommand.SUBSCRIBE ||
+                accessor.getCommand() == StompCommand.SEND) {
             String token = extractToken(accessor);
             if (!jwtProvider.validateToken(token)) {
                 throw new IllegalArgumentException("Invalid token");


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

### 요청 메시지(endpoint = `/publication/chat/*`)

`*`  부분에 사용 될 endpoint는 다음과 존재

- `enter` : 방 입장
- `quit` : 방 퇴장
- `message` : 메시지 전송
- `ready` : 준비 상태로 변경
- `unready` : 준비 해제 상태로 변경
- `change-host` : 방장 변경(message에 변경 할 member id 전송)
- `start-coding` : 문제 풀이 시작
- `end-coding` : 문제 풀이 종료

```json
{
  "roomShortUuid": "c6574c0g",
  "message": "" // 필요한 경우 메시지 포함해서 전달, 현재 message + change-host 경우에만 사용
}
```

### 응답 메시지

요청 메시지를 서버에 보내게 되면 서버에서 필요한 로직을 처리 후 응답 메시지 반환

응답 받은 Type을 기준으로 메시지가 구분 되며, type은 다음과 같음

- `enter` : member id 방 입장
- `quit` : member id 방 퇴장
- `message` : member id 에 의해 메시지 전송 됨(value = 메시지)
- `ready` : member id 준비 완료
- `unready` : member id 준비 해제
- `change-host` : member id로 방장 변경
- `start-coding` : member id에 의해 문제 풀이 시작
- `end-coding` : memberr id에 의해 문제 풀이 종료

```json
{
  "memberId": 1,
  "type": "**",
  "value": null, // 메시지 전송을 제외하면 모두 null
  "timestamp": "2024-03-10T02:14:32.662070"
}
```

## 방 Life Cycle

1. 방 생성(API)
    - 방 생성 API(`/api/v1/rooms`)를 통해 방 생성
    - 서버 측에서 방 생성 정보를 반환
    - 데이터 베이스에 방 정보 생성 + 방장 권한의 참가자 정보 생성
2. 방 참여(SOCKET) ← 다른 참가자는 여기서부터 시작
    - 생성 시 반환 받은 정보 중에 `roomShortUuid` 를 통해 소켓 참여(`CONNECT` + `SUBSCRIBE`)
    - 데이터 베이스에 참여 인원 추가
    - 방 입장(`/publication/enter`) 소켓 메시지 전송
    - 방 참여 중엔 메시지(`/publication/message`)를 통해 메시지 전송 가능
        
3. 풀이 시작 전 퇴장(SOCKET)
    - 방 나가기 버튼을 누르거나 브라우저 종료 시 연결 끊김 요청 전송(`UNSUBSCRIBE` + `DISCONNECT`)
    - 방 퇴장(`/publication/quit`) 소켓 메시지 전송
    - 데이터 베이스에 참여 인원 삭제
    - 방장인 경우 방 참여 순으로 방장 변경
    - 방이 비어진 경우 방 데이터 자체를 삭제하게 됨
4. 준비/준비 해제(SOCKET)
    - 준비(`/publication/ready`) 혹은 준비 해제(`/publication/unready`) 소켓 메시지를 통해 준비 상태 변경 가능
    - 데이터 베이스에 준비 상태 변경 됨
5. 방장 변경(SOCKET)
    - 방장 변경(`/publication/change-host`) 소켓 메시지를 통해 방장 변경 가능
    - 데이터 베이스에 방장 상태 변경 됨
6. 풀이 시작(SOCKET)
    - 방장 권한을 가진 사람이 서버 측에 풀이 시작(`/publication/start-coding`) 전송
    - 응답 받은 참가자들은 풀이 시작
    - 풀이 내역 히스토리에 데이터가 최초 저장 됨
7. 풀이 중 제출(API)
    - 각 사용자는 제출 버튼을 눌러 코드 실행 할 수 있음
        - `/api/v1/compile` : 입력 받은 값 단순 컴파일만 실행
        - `/api/v1/solves/submission` : 테스트 케이스 검사 및 제출한 코드 데이터 베이스에 업데이트
8. 풀이 중 퇴장 및 참여(SOCKET)
    - 풀이 중 퇴장 시엔 참가자 데이터 베이스 삭제되지 않음
    - 풀이 중 퇴장 한 참가자만(Database 상 존재하는 member) 중도 참여 가능
9. 풀이 종료(SOCKET)
    - (타이머 시간이 다 됐을 때) 방장이 풀이 종료(`/publication/end-coding`) 소켓 메시지 전송
    - 백준에 제출 된 문제가 풀이 될 때 까지 일정 시간 대기 필요
10. 풀이 정보 조회(API)
    - 풀이 종료 후 제출한 코드를 확인하기 위해 API(`/api/v1/solves/result/{roomUuid}`) 요청
## 💬리뷰 시 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


