### PR TITLE
소켓 코드 풀이 시작 시 메시지 반환 값에 종료 시간 포함하도록 변경

### DIFF
--- a/src/main/java/ei/algobaroapi/domain/chat/dto/MessageResponse.java
+++ b/src/main/java/ei/algobaroapi/domain/chat/dto/MessageResponse.java
@@ -65,11 +65,11 @@ public class MessageResponse {
         );
     }
 
-    public static MessageResponse startCoding(Long memberId) {
+    public static MessageResponse startCoding(Long memberId, String endTime) {
         return new MessageResponse(
                 memberId,
                 MessageType.START_CODING,
-                null
+                endTime
         );
     }
 

--- a/src/main/java/ei/algobaroapi/domain/chat/service/ChatServiceImpl.java
+++ b/src/main/java/ei/algobaroapi/domain/chat/service/ChatServiceImpl.java
@@ -3,10 +3,12 @@ package ei.algobaroapi.domain.chat.service;
 import ei.algobaroapi.domain.chat.dto.MessageResponse;
 import ei.algobaroapi.domain.member.domain.Member;
 import ei.algobaroapi.domain.member.service.MemberService;
+import ei.algobaroapi.domain.room.dto.response.RoomDetailResponseDto;
 import ei.algobaroapi.domain.room.service.RoomService;
 import ei.algobaroapi.domain.room_member.dto.request.HostManualChangeRequestDto;
 import ei.algobaroapi.domain.room_member.dto.response.RoomExitResponse;
 import ei.algobaroapi.domain.room_member.service.RoomMemberService;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -70,8 +72,15 @@ public class ChatServiceImpl implements ChatService {
 
     @Override
     public void startCodingTest(String roomShortUuid, Long memberId) {
-        roomService.startCodingTest(roomShortUuid);
-        messageService.sendMessage(roomShortUuid, MessageResponse.startCoding(memberId));
+        RoomDetailResponseDto roomDetailResponseDto = roomService.startCodingTest(roomShortUuid);
+        Integer timeLimitMinute = roomDetailResponseDto.getTimeLimit();
+        messageService.sendMessage(
+                roomShortUuid,
+                MessageResponse.startCoding(
+                        memberId,
+                        LocalDateTime.now().plusMinutes(timeLimitMinute).toString()
+                )
+        );
     }
 
     @Override


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

- [x] 소켓 코드 풀이 시작 시 메시지 반환 값에 종료 시간 포함하도록 변경

## 💬리뷰 시 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


